### PR TITLE
fix: encode oauth scope param to escape all spaces in authorize URL

### DIFF
--- a/ui/src/helpers/auth.js
+++ b/ui/src/helpers/auth.js
@@ -84,7 +84,7 @@ export class AuthorizationFlowPKCE extends OauthFlow {
   async authorize() {
     await this.generateCodeChallenge()
     this.save()
-    redirectTo(`${this.authorizeUrl}?response_type=code&client_id=${this.clientId}&code_challenge=${this.codeChallenge}&code_challenge_method=S256&scope=${this.scope.replace(' ', '+')}&redirect_uri=${encodeURIComponent(formatInternalRedirect(this.redirectPath))}${this.authorizeAdditionalParams}`);
+    redirectTo(`${this.authorizeUrl}?response_type=code&client_id=${this.clientId}&code_challenge=${this.codeChallenge}&code_challenge_method=S256&scope=${encodeURIComponent(this.scope)}&redirect_uri=${encodeURIComponent(formatInternalRedirect(this.redirectPath))}${this.authorizeAdditionalParams}`);
   }
 
   async callback() {


### PR DESCRIPTION
## Problem
In `ui/src/helpers/auth.js`, `AuthorizationFlowPKCE.authorize()` built the `scope` query param with:

```js
scope=${this.scope.replace(' ', '+')}
```

`String.prototype.replace` with a string (non-global) argument only replaces the **first** occurrence. A multi-scope value like `"openid email profile"` became `"openid+email profile"` — the remaining raw space was left unencoded in the URL.

This was also inconsistent with `ImplicitFlow.authorize()` (same file), which correctly uses `encodeURIComponent(this.scope)`.

## Fix
Use `encodeURIComponent(this.scope)` for the scope param in `AuthorizationFlowPKCE.authorize()`, matching the existing convention used by `ImplicitFlow.authorize()` elsewhere in the file. `encodeURIComponent` correctly escapes all spaces (as `%20`), which is valid per the OAuth/URL spec.

## Testing
Verified the diff is a single-line, minimal change consistent with existing code style in the file.

Closes #40

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZWfJfvGVV3o7JxzUHGBMG)_