### PR TITLE
fix: enforce admin-check result in post_guilds_id

### DIFF
--- a/api/src/guilds/mod.rs
+++ b/api/src/guilds/mod.rs
@@ -94,7 +94,9 @@ async fn post_guilds_id(
     Extension(current_user): Extension<CurrentUser>,
     State(app_state): State<AppState>,
 ) -> Result<Json<Value>, StatusCode> {
-    is_client_admin_guild(guild_id, &current_user, &app_state.discord_bot).await?;
+    if !is_client_admin_guild(guild_id, &current_user, &app_state.discord_bot).await? {
+        return Err(StatusCode::FORBIDDEN);
+    }
     let guild = Guild::from_db(guild_id, &app_state.pg_pool)
         .await
         .unwrap_or(Guild {


### PR DESCRIPTION
## What was wrong

`post_guilds_id` in `api/src/guilds/mod.rs` called `is_client_admin_guild(...).await?` and discarded the returned `bool`. The `?` only propagates on `Err`; an `Ok(false)` result (i.e. the caller is a guild member but *not* an admin) fell through unnoticed, and the handler returned the full guild config — including `verify.user_links`, which contains every verified member's email address.

## The fix

Check the boolean result and reject non-admins with `403 Forbidden`, matching the existing pattern used in `api/src/guilds/verify/controllers.rs` (`put_roles_id` / `delete_roles_id`):

```rust
if !is_client_admin_guild(guild_id, &current_user, &app_state.discord_bot).await? {
    return Err(StatusCode::FORBIDDEN);
}
```

## Verification

`cargo check -p api` compiles cleanly with the change.

Closes #14

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZWfJfvGVV3o7JxzUHGBMG)_