### PR TITLE
fix: remove unused add() placeholder from common

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,17 +1,2 @@
 pub mod audit;
 pub mod dsql;
-
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}


### PR DESCRIPTION
## Summary
- Removes the default cargo-generated `pub fn add(left: u64, right: u64) -> u64` placeholder and its `it_works` test from `common/src/lib.rs`.
- This was leftover `cargo new --lib` boilerplate publicly exported from the shared `common` crate, with no callers anywhere in the workspace.

## Verification
- Searched the whole workspace for references to `add(` from `common` — none found.
- `cargo check --workspace` passes cleanly (only a pre-existing, unrelated warning about an unread `id` field in `consumer/src/audit/models.rs`).

Closes #52

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZWfJfvGVV3o7JxzUHGBMG)_