### PR TITLE
fix: remove unauthorized, unimplemented get_users route

### DIFF
--- a/api/src/users/mod.rs
+++ b/api/src/users/mod.rs
@@ -18,16 +18,11 @@ use twilight_model::user::CurrentUser;
 
 pub fn router() -> axum::Router<AppState> {
     axum::Router::new()
-        .route("/", get(get_users))
         .route("/@me", get(get_users_me))
         .route("/{user_id}", get(get_users_id))
         .nest("/{user_id}/links", links::router())
         .nest("/{user_id}/link_guilds", link_guilds::router())
         .layer(CorsLayer::permissive())
-}
-
-async fn get_users() -> Json<Value> {
-    todo!()
 }
 
 async fn get_users_me(


### PR DESCRIPTION
## Problem
`GET /users/` was registered against `get_users()`, which is `todo!()` — every call panics (500). Even if implemented, the handler takes no `current_user` extension, so it has no authorization, and listing all users would leak the full user list (a privacy problem).

## Fix
Removes the `/` route and the `get_users()` handler entirely, per the resolution suggested in the issue. `/@me` and `/{user_id}` (which are properly authorized, restricting access to the requesting user's own record) are untouched.

## Testing
- `cargo check -p api` passes with no errors or new warnings.

Closes #35

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZWfJfvGVV3o7JxzUHGBMG)_