### PR TITLE
fix: reset loading state and roll back on toggle_guild failure

### DIFF
--- a/ui/src/components/verify/LinkedGuildsSelect.vue
+++ b/ui/src/components/verify/LinkedGuildsSelect.vue
@@ -18,17 +18,24 @@ let loadingGuilds = ref([])
 async function toggle_guild(guildId) {
   loadingGuilds.value.push(guildId)
   let linkedBool = isLinked(guildId)
+  let snapshot = [...props.user.linkGuilds]
   props.user.linkGuilds = props.user.linkGuilds.filter(lg => lg.guildId !== guildId);
 
-  if (linkedBool) {
-    await deleteLinkGuild(guildId)
-  } else {
-    await putLinkGuild(guildId)
-    props.user.linkGuilds.push(new LinkGuild(guildId, true));
+  try {
+    if (linkedBool) {
+      await deleteLinkGuild(guildId)
+    } else {
+      await putLinkGuild(guildId)
+      props.user.linkGuilds.push(new LinkGuild(guildId, true));
+    }
+    props.user.saveCache()
+  } catch (err) {
+    props.user.linkGuilds = snapshot
+    console.log(err)
+    window.alert(err.response?.data ?? 'Failed to update server link')
+  } finally {
+    loadingGuilds.value = loadingGuilds.value.filter(guild => guild !== guildId)
   }
-  props.user.saveCache()
-
-  loadingGuilds.value = loadingGuilds.value.filter(guild => guild !== guildId)
 }
 
 function isLinked(guildId) {


### PR DESCRIPTION
## Bug
`LinkedGuildsSelect.toggle_guild` (in `ui/src/components/verify/LinkedGuildsSelect.vue`) optimistically removed the guild from `props.user.linkGuilds` and pushed `guildId` onto `loadingGuilds`, but then awaited `deleteLinkGuild`/`putLinkGuild` with no error handling. If either call rejected (network error, 401, backend 500):

- `guildId` was never removed from `loadingGuilds`, leaving the button permanently disabled/spinning until a page reload.
- The optimistic removal from `linkGuilds` was never rolled back, so the guild appeared unlinked in the UI even though the server state hadn't changed, and the cache was never (or inconsistently) saved.

## Fix
Wrapped the API call in `try/catch/finally`:
- Snapshot `linkGuilds` before the optimistic update and restore it in the `catch` block on failure, along with a `window.alert` surfacing the error (matching the existing pattern used in the sibling `LinkedAccountsTable.vue` component).
- Moved `loadingGuilds` cleanup into a `finally` block so the button always stops loading regardless of success or failure.

Closes #56

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZWfJfvGVV3o7JxzUHGBMG)_