### PR TITLE
fix: LinkedAccountsTable toRef misuse and unsafe reactive mutation

### DIFF
--- a/ui/src/components/verify/LinkedAccountsTable.vue
+++ b/ui/src/components/verify/LinkedAccountsTable.vue
@@ -2,15 +2,16 @@
 
 import GoogleIcon from "../icons/GoogleIcon.vue";
 import MicrosoftIcon from "../icons/MicrosoftIcon.vue";
-import {onMounted, ref, toRef} from "vue";
+import {onMounted, ref} from "vue";
 import axios from "axios";
 import ConfirmModal from "../ConfirmModal.vue";
 import {User} from "../../stores/user.js";
 
 const VITE_KB_API_URL = import.meta.env.VITE_KB_API_URL
-const userRef = toRef(User.loadCache())
+const userRef = ref(User.loadCache())
 const linkedAccounts = ref(undefined)
 const activeEvent = ref()
+const pendingUnlinks = ref(new Set())
 
 function loadAccounts() {
   //Call with user.token
@@ -30,8 +31,17 @@ function unloadAccounts() {
 }
 
 function unlinkAccount(event) {
-  let toBeRemoved = linkedAccounts.value[event.target.id]
-  delete linkedAccounts.value[event.target.id]
+  const id = event.target.id
+  if (pendingUnlinks.value.has(id)) return
+
+  const toBeRemoved = linkedAccounts.value[id]
+  if (!toBeRemoved) return
+
+  const snapshot = linkedAccounts.value
+  const {[id]: _removed, ...rest} = linkedAccounts.value
+  linkedAccounts.value = rest
+  pendingUnlinks.value = new Set(pendingUnlinks.value).add(id)
+
   axios.delete(`${VITE_KB_API_URL}/users/${userRef.value.userId}/links/${encodeURIComponent(toBeRemoved.link_address)}`,
       {
         headers: {
@@ -40,12 +50,15 @@ function unlinkAccount(event) {
       }
   ).catch(
       (err) => {
-        linkedAccounts.value[event.target.id] = toBeRemoved
+        linkedAccounts.value = snapshot
         console.log(err)
         window.alert(err.response.data)
       }
-  )
-
+  ).finally(() => {
+    const remaining = new Set(pendingUnlinks.value)
+    remaining.delete(id)
+    pendingUnlinks.value = remaining
+  })
 }
 
 onMounted(() => {
@@ -75,7 +88,7 @@ onMounted(() => {
         </td>
         <td>{{ email }}</td>
         <td>
-          <button class="btn btn-xs hover:btn-error" @click="activeEvent = $event" :id="email">unlink</button>
+          <button class="btn btn-xs hover:btn-error" @click="activeEvent = $event" :id="email" :disabled="pendingUnlinks.has(email)">unlink</button>
         </td>
       </tr>
       </tbody>


### PR DESCRIPTION
## Bug

In `ui/src/components/verify/LinkedAccountsTable.vue`:

1. `const userRef = toRef(User.loadCache())` called `toRef` with a single plain-object argument. `toRef` is meant to be used as `toRef(object, key)` or `toRef(getter)` — called this way it does not produce the reactive ref to the current user that the code assumes, and it snapshots the cached user at setup time rather than reacting to login/logout.
2. `unlinkAccount` optimistically mutated the `linkedAccounts` object in place via `delete linkedAccounts.value[id]` and restored it on error via index assignment (`linkedAccounts.value[id] = toBeRemoved`). On error this re-inserts the entry at the end of iteration order (reordering the table), and there was no in-flight/loading state, so rapid double-clicks could fire duplicate DELETE requests.

## Fix

- Replaced `toRef(User.loadCache())` with `ref(User.loadCache())`, matching the pattern already used elsewhere in the codebase (e.g. `VerifyComponent.vue`, `DashBaseView.vue`, `VerifyView.vue`, `LoginView.vue`).
- Reworked `unlinkAccount` to use immutable updates: it builds a new object without the removed key via object destructuring/rest instead of `delete`, and restores the pre-removal snapshot wholesale on error, preserving original ordering.
- Added a `pendingUnlinks` set to track in-flight unlink requests and disable the corresponding row's unlink button while a request is pending, preventing duplicate DELETE calls from double-clicks.

Closes #57

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZWfJfvGVV3o7JxzUHGBMG)_