### PR TITLE
fix: remove unneeded python setup from api-deploy CI and stale README docs

### DIFF
--- a/.github/workflows/api-deploy.yml
+++ b/.github/workflows/api-deploy.yml
@@ -19,10 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
       - name: Setup AWS CLI
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
@@ -31,10 +27,12 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
+      - name: Install cargo-lambda
+        uses: jaxxstorm/action-install-gh-release@v1
+        with:
+          repo: cargo-lambda/cargo-lambda
       - name: Install dependencies
-        run: |
-          pip install cargo-lambda
-          cargo install sqlx-cli
+        run: cargo install sqlx-cli
       - name: Build
         run: cargo lambda build --release --output-format zip -p api -p consumer
 

--- a/README.md
+++ b/README.md
@@ -34,35 +34,50 @@ CloudFormation will be used to spin up the AWS services defined in the [Cloud Ar
 These instructions will get you a copy of the project up and running on your local machine for development and testing purposes. See deployment for notes on how to deploy the project on a live system.
 
 ## Prerequisites
-This application uses python 3.11 which you can download [here](https://www.python.org/downloads/)
+The `api`, `gateway`, `consumer` and `common` crates are a Rust workspace built and deployed with
+[`cargo lambda`](https://www.cargo-lambda.info/). Install the Rust toolchain [here](https://www.rust-lang.org/tools/install)
+and then install `cargo lambda` following its [installation guide](https://www.cargo-lambda.info/guide/installation.html).
 
-All python packages you need to run on serverless can be found in the [lambda-requirements.txt](lambda-requirements.txt).
-Before running the bot you must install these as so:
+The `ui` directory is a Vue3/TypeScript frontend that requires [Node.js](https://nodejs.org/) (v22+). Install its
+dependencies with:
 
 ```bash
-$ pip3 install -r lambda-requirements.txt
-``` 
-
-If you would like to run a server version locally, you will instead need to install from [requirements.txt](requirements.txt)
-```bash
-$ pip3 install -r requirements.txt
+$ cd ui
+$ npm install
 ```
 
 ### Environment Variables
-This project does not provide `.env` support by default to reduce package size for serverless. 
-You will instead have to provide the environment variables either as part of serverless deployment, or at runtime if running the server.
+This project does not provide `.env` support by default to reduce package size for serverless.
+You will instead have to provide the environment variables either as part of serverless deployment, or at runtime if running locally.
 
-The environment variables required are listed below:
+The environment variables required by the `api`/`consumer`/`gateway` crates are listed below:
 
-`PUBLIC_KEY` : The public key from the application in the Discord developers portal<br>
-`DISCORD_TOKEN` : The secret token from the bot in the Discord developers portal
+`DSQL_USER` : The username used to connect to the Aurora DSQL database<br>
+`DSQL_ENDPOINT` : The endpoint hostname of the Aurora DSQL database<br>
+`DISCORD_BOT_TOKEN` : The secret token from the bot in the Discord developers portal<br>
+`DISCORD_PUBLIC_KEY` : The public key from the application in the Discord developers portal<br>
+`DEPLOYMENT_ENV` : The deployment environment name (e.g. `dev` or `prod`)<br>
+`SQS_URL` : The URL of the SQS queue used for audit events
+
+The `ui` app additionally requires the following build-time variables:
+
+`VITE_KB_API_URL` : The base URL of the deployed `api`<br>
+`VITE_DISCORD_CLIENT_ID` : The Discord OAuth2 client ID<br>
+`VITE_GOOGLE_CLIENT_ID` : The Google OAuth2 client ID<br>
+`VITE_MICROSOFT_CLIENT_ID` : The Microsoft OAuth2 client ID
 
 ### Running KB2
 You can use the [Infrastructure as Code](#Infrastructure-as-Code) to spin up your serverless environment.
 
-If you are using a server the following can be used:
+To build the Rust crates locally:
 ```bash
-$ python3 ./kb2/main.py
+$ cargo lambda build --release --output-format zip -p api -p consumer
+```
+
+To run the `ui` app locally:
+```bash
+$ cd ui
+$ npm run dev
 ```
 
 ## License


### PR DESCRIPTION
## Summary
- `api-deploy.yml` installed Python 3.11 (`actions/setup-python`) solely to `pip install cargo-lambda`, even though `api`/`consumer`/`gateway`/`common` are an all-Rust workspace built with `cargo lambda`. Replaced the Python setup with the maintained `jaxxstorm/action-install-gh-release@v1` action pointed at `cargo-lambda/cargo-lambda`, as suggested in the issue.
- The README Prerequisites/Getting Started section still documented a legacy Python project (`lambda-requirements.txt`, `requirements.txt`, `pip3 install`, `python3 ./kb2/main.py`) that no longer exists. Rewrote it to describe the actual Rust toolchain + `cargo lambda build`, the `ui/` Vue3/TypeScript Node app, and the real environment variables used by the crates (`DSQL_USER`, `DSQL_ENDPOINT`, `DISCORD_BOT_TOKEN`, `DISCORD_PUBLIC_KEY`, `DEPLOYMENT_ENV`, `SQS_URL`, `VITE_*`).

## Test plan
- [x] Verified `DSQL_USER`, `DSQL_ENDPOINT`, `DISCORD_BOT_TOKEN`, `DISCORD_PUBLIC_KEY`, `DEPLOYMENT_ENV`, `SQS_URL`, and `VITE_*` env vars are actually referenced in `api/src`, `consumer/src`, `gateway/src`, and `ui-deploy.yml`.
- [ ] CI run of `api-deploy.yml` on this branch (no `api/**` changes, so workflow won't trigger via `paths`; can be manually verified via `workflow_dispatch` if desired).

Closes #50

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZWfJfvGVV3o7JxzUHGBMG)_