### PR TITLE
fix: correct ui-deploy.yml path filter and document env mapping

### DIFF
--- a/.github/workflows/ui-deploy.yml
+++ b/.github/workflows/ui-deploy.yml
@@ -5,7 +5,7 @@ on:
       - main
     paths:
       - ui/**
-      - ui-deploy.yml
+      - .github/workflows/ui-deploy.yml
     tags:
       - '*.*.*'
 permissions:
@@ -13,6 +13,8 @@ permissions:
 
 jobs:
   build-deploy:
+    # Ref -> environment mapping: pushes to main deploy to "dev";
+    # semver tag pushes (e.g. 1.2.3) deploy to "prod".
     environment: ${{ github.ref == 'refs/heads/main' && 'dev' || 'prod' }}
     name: Build & Deploy 🪣
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Fixed the `paths:` filter in `.github/workflows/ui-deploy.yml` to reference the workflow's actual location (`.github/workflows/ui-deploy.yml`) instead of a nonexistent root-level `ui-deploy.yml`, so changes to the workflow file itself now correctly trigger it.
- Added a comment documenting the intended ref→environment mapping (`main` → `dev`, semver tag pushes like `1.2.3` → `prod`) next to the `environment:` expression, since this "tag = prod" convention is implicit and easy to mistake for a bug.

## Why not also change the env logic?
The env expression itself (`github.ref == 'refs/heads/main' && 'dev' || 'prod'`) was flagged in the issue as *possibly* confusing, but the issue author explicitly asked to "confirm it matches intent" rather than requesting a swap. Since `branches` + `tags` under one `push` trigger is OR-combined, this expression is actually consistent with a deliberate "main→dev, tag→prod" release convention (the same pattern also appears in `api-deploy.yml`). Flipping it without confirming intent risked breaking the real deploy flow, so this PR only documents the behavior via a comment rather than guessing at a change. If the mapping is in fact wrong, please advise and I'll follow up.

Closes #49

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZWfJfvGVV3o7JxzUHGBMG)_