### PR TITLE
fix(gateway): don't panic shard loop on bad interaction callback response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,6 +1564,7 @@ name = "gateway"
 version = "2.0.0"
 dependencies = [
  "reqwest",
+ "serde_json",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -10,3 +10,4 @@ twilight-model = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
+serde_json = { workspace = true }

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -3,6 +3,18 @@ use reqwest::header::{AUTHORIZATION, CONTENT_TYPE};
 use twilight_gateway::{EventTypeFlags, Intents, Shard, ShardId, StreamExt as _};
 use twilight_model::http::interaction::InteractionResponse;
 
+/// Parse the body of the local API's interaction response into an
+/// `InteractionResponse` we can relay back to Discord.
+///
+/// This is split out from the event loop (see issue #53) so that a
+/// malformed/unexpected body (bad JSON, an error payload, an empty body,
+/// etc.) is reported as an `Err` instead of panicking via `.unwrap()`,
+/// which used to take down the entire shard loop on a single bad
+/// interaction.
+fn parse_interaction_response(body: &[u8]) -> Result<InteractionResponse, serde_json::Error> {
+    serde_json::from_slice(body)
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // Initialize the tracing subscriber.
@@ -36,15 +48,20 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                     match r.status() {
                         reqwest::StatusCode::OK => {
                             let headers = r.headers().clone();
-                            match r.json::<InteractionResponse>().await {
-                                Ok(body) => {
-                                    let callback_url = format!("https://discord.com/api/v10/interactions/{}/{}/callback", interaction.id, interaction.token);
-                                    if let Err(e) = client.post(callback_url).json(&body).headers(headers).send().await {
-                                        tracing::error!(?e, "failed to post interaction callback");
+                            match r.bytes().await {
+                                Ok(bytes) => match parse_interaction_response(&bytes) {
+                                    Ok(body) => {
+                                        let callback_url = format!("https://discord.com/api/v10/interactions/{}/{}/callback", interaction.id, interaction.token);
+                                        if let Err(e) = client.post(callback_url).json(&body).headers(headers).send().await {
+                                            tracing::error!(?e, "failed to post interaction callback");
+                                        }
                                     }
-                                }
+                                    Err(e) => {
+                                        tracing::error!(?e, "invalid interaction response body");
+                                    }
+                                },
                                 Err(e) => {
-                                    tracing::error!(?e, "invalid interaction response body");
+                                    tracing::error!(?e, "failed to read interaction response body");
                                 }
                             }
                         },
@@ -62,4 +79,56 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression test for issue #53: previously this path was
+    /// `r.json::<InteractionResponse>().await.unwrap()`, which would panic
+    /// (and take down the whole shard loop) whenever the local API returned
+    /// a body that wasn't a valid `InteractionResponse` — e.g. an error
+    /// payload. The fix replaced the unwrap with proper error handling, and
+    /// `parse_interaction_response` is the extracted piece of that logic.
+    #[test]
+    fn parse_interaction_response_rejects_malformed_body_instead_of_panicking() {
+        // Something that is valid JSON but not a valid InteractionResponse
+        // (e.g. an error object the local API might return on failure).
+        let bad_body = br#"{"error": "internal server error"}"#;
+
+        let result = parse_interaction_response(bad_body);
+
+        assert!(
+            result.is_err(),
+            "malformed interaction response body should be rejected via Err, not panic"
+        );
+    }
+
+    /// Also cover a completely empty body (e.g. from a 200 with no content),
+    /// which is another way the old `.unwrap()` used to panic.
+    #[test]
+    fn parse_interaction_response_rejects_empty_body_instead_of_panicking() {
+        let result = parse_interaction_response(b"");
+
+        assert!(
+            result.is_err(),
+            "empty interaction response body should be rejected via Err, not panic"
+        );
+    }
+
+    /// A well-formed InteractionResponse body should still parse
+    /// successfully, so the fix doesn't reject valid responses along with
+    /// the invalid ones.
+    #[test]
+    fn parse_interaction_response_accepts_valid_body() {
+        let good_body = br#"{"type": 4, "data": {"content": "pong"}}"#;
+
+        let result = parse_interaction_response(good_body);
+
+        assert!(
+            result.is_ok(),
+            "valid interaction response body should parse successfully, got: {result:?}"
+        );
+    }
 }

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -10,8 +10,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let token = env::var("DISCORD_BOT_TOKEN")?;
     let intents = Intents::GUILD_MESSAGES;
-    let mut shard = Shard::new(ShardId::ONE, token, intents);
-    let token = env::var("DISCORD_BOT_TOKEN")?;
+    let mut shard = Shard::new(ShardId::ONE, token.clone(), intents);
     let client = reqwest::Client::new();
     tracing::info!("created shard");
 
@@ -37,9 +36,17 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                     match r.status() {
                         reqwest::StatusCode::OK => {
                             let headers = r.headers().clone();
-                            client.post(format!("https://discord.com/api/v10/interactions/{}/{}/callback",interaction.id, interaction.token))
-                                .json(&r.json::<InteractionResponse>().await.unwrap())
-                                .headers(headers).send().await.unwrap();
+                            match r.json::<InteractionResponse>().await {
+                                Ok(body) => {
+                                    let callback_url = format!("https://discord.com/api/v10/interactions/{}/{}/callback", interaction.id, interaction.token);
+                                    if let Err(e) = client.post(callback_url).json(&body).headers(headers).send().await {
+                                        tracing::error!(?e, "failed to post interaction callback");
+                                    }
+                                }
+                                Err(e) => {
+                                    tracing::error!(?e, "invalid interaction response body");
+                                }
+                            }
                         },
                         _ => {
                             tracing::error!(?r, "error sending interaction");


### PR DESCRIPTION
## Bug

In `gateway/src/main.rs`, the interaction relay loop had two problems:

1. `DISCORD_BOT_TOKEN` was read from the environment twice — once to build the `Shard`, and again immediately after, because the first `token` value was moved into `Shard::new`.
2. The interaction callback path used `.unwrap()` twice: once when deserializing the API response body as `InteractionResponse`, and once when sending the callback POST to Discord. If the local API returned a body that wasn't a valid `InteractionResponse` (e.g. an error JSON or empty body), or if the callback POST failed (transient network error), the panic would unwind the `while let` shard loop and kill the entire gateway process — taking down the whole Discord connection instead of just failing that one interaction.

## Fix

- Read `DISCORD_BOT_TOKEN` once and `.clone()` it before moving into `Shard::new`, so it's still available for building the `Authorization` header later.
- Replace both `.unwrap()`s with proper error handling: on a bad/undecodable response body, log via `tracing::error!` and move on; on a failed callback POST, log via `tracing::error!` and move on. No unwraps remain in the event loop for this path, so a single bad interaction can no longer take down the shard.

Verified with `cargo check -p gateway` (passes with no errors/warnings).

Closes #53

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZWfJfvGVV3o7JxzUHGBMG)_