### PR TITLE
fix: VerifyComponent addVerifyRole guard checks ref values, not ref objects

### DIFF
--- a/ui/src/components/dashboard/VerifyComponent.vue
+++ b/ui/src/components/dashboard/VerifyComponent.vue
@@ -40,7 +40,7 @@ async function updateGuild() {
 }
 
 async function addVerifyRole() {
-  if (!roleSelected || !modelPattern) {
+  if (!validAdd()) {
     alert("Please fill in all fields.");
     return;
   }


### PR DESCRIPTION
## Bug

In `ui/src/components/dashboard/VerifyComponent.vue`, `addVerifyRole()` had a validation guard that checked the truthiness of the `roleSelected` and `modelPattern` `ref`/`defineModel` objects themselves, rather than their `.value`:

```js
if (!roleSelected || !modelPattern) {
  alert("Please fill in all fields.");
  return;
}
```

Since a Vue `ref` is always a truthy object, this guard could never actually fire, so the "please fill in all fields" check was dead code.

## Fix

The component already has a `validAdd()` helper (combining `validRole()`/`validPattern()`) that correctly reads `.value` and is used to disable the "Add" button in the template. This change reuses that helper in `addVerifyRole()` instead of duplicating the (broken) inline check:

```js
if (!validAdd()) {
  alert("Please fill in all fields.");
  return;
}
```

This matches the suggested resolution in the issue and keeps validation logic in one place.

Closes #44

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZWfJfvGVV3o7JxzUHGBMG)_