### PR TITLE
fix: remove dead Guild.save() with no matching API route

### DIFF
--- a/ui/src/stores/guild.js
+++ b/ui/src/stores/guild.js
@@ -166,13 +166,11 @@ export class Guild {
   guildId
   verify
   vote
-  userLinks
 
-  constructor(guildId, verify, vote, userLinks) {
+  constructor(guildId, verify, vote) {
     this.guildId = guildId
     this.verify = verify
     this.vote = vote
-    this.userLinks = userLinks
   }
 
   toJson() {
@@ -208,13 +206,5 @@ export class Guild {
       }
     });
     return r.data.map(g => Guild.fromJson(g))
-  }
-
-  async save() {
-    await axios.put(`${VITE_KB_API_URL}/guilds/${this.guildId}`, this.toJson(), {
-      headers: {
-        'Authorization': 'Discord ' + user.token.accessToken
-      }
-    });
   }
 }


### PR DESCRIPTION
## Bug
`Guild.save()` in `ui/src/stores/guild.js` called `PUT /guilds/{id}`, but the API's guild router (`api/src/guilds/mod.rs`) only defines `GET`/`POST` on `/` and `/{guild_id}` — there is no `PUT` handler. Any caller of `Guild.save()` would get a 405.

## Investigation
- Confirmed the API router has no `PUT` route for `/guilds/{guild_id}`.
- Confirmed `Guild.save()` is not called anywhere else in the UI codebase — mutations already go through the `verify`/`votes` sub-resource endpoints.
- Confirmed the `userLinks` constructor arg on the `Guild` class was also unused/dead — `new Guild()` is only ever constructed via `Guild.fromJson`, which never sets it.

## Fix
Per the issue's suggested resolution, removed the dead `Guild.save()` method and the unused `userLinks` constructor arg/field from the `Guild` class, since guild persistence is intentionally handled only via the sub-resource endpoints.

Closes #41

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZWfJfvGVV3o7JxzUHGBMG)_