### PR TITLE
fix: treat loadMemGuilds cache as a Map, not a plain object

### DIFF
--- a/ui/src/pages/dashboard/DashBaseView.vue
+++ b/ui/src/pages/dashboard/DashBaseView.vue
@@ -59,10 +59,10 @@ async function enrichMeta(gid) {
 }
 
 function loadMemGuilds() {
-  let memGuilds = JSON.parse(localStorage.getItem('guilds'), reviver);
-  if (memGuilds === null) return;
-  for (let k of Object.keys(memGuilds)) {
-    memGuilds.set(k, Guild.fromJson(memGuilds[k]));
+  const memGuilds = JSON.parse(localStorage.getItem('guilds'), reviver);
+  if (!(memGuilds instanceof Map)) return;
+  for (const [k, v] of memGuilds) {
+    memGuilds.set(k, Guild.fromJson(v));
   }
   guildsKb.value = memGuilds;
   if (guildsKb.value.size > 0) {


### PR DESCRIPTION
## Bug

`saveMemGuilds` serializes `guildsKb` (a `Map`) using the `replacer`, which turns it into `{ dataType: 'Map', value: [...] }`. `loadMemGuilds` parses this back with the `reviver`, which correctly reconstructs a real `Map`.

However, `loadMemGuilds` then treated the result as a plain object:

```js
for (let k of Object.keys(memGuilds)) {          // Object.keys(map) -> []
  memGuilds.set(k, Guild.fromJson(memGuilds[k])); // memGuilds[k] is undefined for a Map
}
```

- `Object.keys()` on a `Map` returns `[]`, so the hydration loop never runs, **or**
- if a legacy/plain-object cache value existed, `.set()` would throw `TypeError: memGuilds.set is not a function`.

Either way, the "load guilds from cache" fast path was broken, and the dashboard only recovered once the async `sync_guilds_kb()` network call completed.

## Fix

`guildsKb` and friends (`guildMetaMap`, etc.) are used as `Map`s consistently everywhere else in this file (`.set()`, `.size`), and the `reviver` already reconstructs a `Map`. So `loadMemGuilds` now:

- Guards with `memGuilds instanceof Map` instead of `=== null`.
- Iterates entries directly (`for (const [k, v] of memGuilds)`) instead of `Object.keys()`/bracket indexing.

```js
function loadMemGuilds() {
  const memGuilds = JSON.parse(localStorage.getItem('guilds'), reviver);
  if (!(memGuilds instanceof Map)) return;
  for (const [k, v] of memGuilds) {
    memGuilds.set(k, Guild.fromJson(v));
  }
  guildsKb.value = memGuilds;
  if (guildsKb.value.size > 0) {
    guildsLoaded.value = true;
  }
  currentGuildId.value = JSON.parse(localStorage.getItem('currentGuildId')|| null) ;
}
```

Closes #42

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZWfJfvGVV3o7JxzUHGBMG)_