### PR TITLE
fix: move health check side effect out of RouterView computed getter

### DIFF
--- a/ui/src/router/RouterView.vue
+++ b/ui/src/router/RouterView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import NotFoundView from "../pages/NotFoundView.vue";
 import DiscordAuthCallback from "../pages/auth/DiscordAuthCallback.vue";
 import VerifyMicrosoftCallback from "../pages/verify/VerifyMicrosoftCallback.vue";
@@ -31,11 +31,16 @@ window.addEventListener('hashchange', () => {
   currentPath.value = window.location.pathname
 })
 
-const currentView = computed(() => {
+onMounted(() => {
   Health.loadHealth().then(() => console.log("Backend is Healthy"))
-  for (const path in routes) {
-    if (new RegExp(path).test(currentPath.value)) {
-      return routes[path]
+})
+
+const compiledRoutes = Object.entries(routes).map(([path, component]) => [new RegExp(path), component])
+
+const currentView = computed(() => {
+  for (const [regex, component] of compiledRoutes) {
+    if (regex.test(currentPath.value)) {
+      return component
     }
   }
   return NotFoundView


### PR DESCRIPTION
## Bug
`ui/src/router/RouterView.vue`'s `currentView` computed getter called `Health.loadHealth()` as a side effect on every recomputation. `computed` getters are meant to be pure/cached; instead this fired a redundant backend health-check network request every time `currentPath` changed (e.g. on every route navigation), and also recompiled a `RegExp` for every route on every evaluation.

## Fix
- Moved the `Health.loadHealth()` warm-up call into `onMounted`, so it fires once when the component mounts instead of on every computed recomputation.
- Pre-compiled the route path regexes once outside the computed getter (`compiledRoutes`), so `currentView` no longer allocates new `RegExp` instances on every evaluation.

The `currentView` computed getter is now pure, deriving its value only from `currentPath` and the pre-compiled routes.

## Out of scope
The issue also noted that navigation relies on `hashchange` while `currentPath` reads `window.location.pathname`, so SPA path navigations without a hash change won't update the view. That's a separate, pre-existing routing concern and isn't addressed here to keep this fix minimal and focused.

Closes #43

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZWfJfvGVV3o7JxzUHGBMG)_