### PR TITLE
fix: use crypto.getRandomValues for PKCE code_verifier generation

### DIFF
--- a/ui/src/helpers/auth.js
+++ b/ui/src/helpers/auth.js
@@ -69,9 +69,13 @@ export class AuthorizationFlowPKCE extends OauthFlow {
   }
 
   async generateCodeChallenge() {
-    this.codeVerifier = Array(43 + 1)
-      .join()
-      .replace(/(.|$)/g, (match) => ((match.length ? Math.random() : '').toString(36).charAt(2 + (match.length ? Math.floor(Math.random() * 4) : 0))));
+    // Generate a cryptographically random code_verifier per RFC 7636 (43-128 chars,
+    // unreserved character set). 32 random bytes base64url-encoded yields 43 chars.
+    let randomBytes = crypto.getRandomValues(new Uint8Array(32))
+    this.codeVerifier = btoa(String.fromCharCode(...randomBytes))
+      .replace(/=/g, '') // Remove padding characters
+      .replace(/\+/g, '-') // Replace + with -
+      .replace(/\//g, '_'); // Replace / with _
 
     let hash = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(this.codeVerifier))
 


### PR DESCRIPTION
## Bug

`AuthorizationFlowPKCE.generateCodeChallenge()` in `ui/src/helpers/auth.js` generated the PKCE `code_verifier` using `Math.random()` combined with a fragile `charAt` indexing trick:

```js
this.codeVerifier = Array(43 + 1)
  .join()
  .replace(/(.|$)/g, (match) => ((match.length ? Math.random() : '').toString(36).charAt(2 + (match.length ? Math.floor(Math.random() * 4) : 0))));
```

This has two problems:
1. `Math.random()` is not cryptographically secure, undermining PKCE's guarantee of an unguessable verifier (RFC 7636 requires cryptographic randomness).
2. The length was unreliable — `charAt` on a `Math.random().toString(36)` string can index past the end and return `''`, so the resulting verifier was frequently shorter than the RFC-required 43-character minimum, causing some IdPs to reject it.

## Fix

Generate the `code_verifier` from 32 cryptographically random bytes via `crypto.getRandomValues`, then base64url-encode them (matching the same encoding already used for `code_challenge` a few lines below), guaranteeing both cryptographic randomness and a consistent 43-character length.

Closes #39

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZWfJfvGVV3o7JxzUHGBMG)_