### PR TITLE
fix(ui): pass actual link_address value in User.loadMe

### DIFF
--- a/ui/src/stores/user.js
+++ b/ui/src/stores/user.js
@@ -77,7 +77,7 @@ export class User {
     })
     return new User(
       r.data['user_id'],
-      r.data['links'].map(l => new Link(['link_address'], l['linked_at'], l['active'])),
+      r.data['links'].map(l => new Link(l['link_address'], l['linked_at'], l['active'])),
       r.data['link_guilds'].map(LinkGuild.fromJson),
       token
     )


### PR DESCRIPTION
## Bug

In `ui/src/stores/user.js`, `User.loadMe` constructed each `Link` with the literal array `['link_address']` instead of the actual value `l['link_address']`:

```js
r.data['links'].map(l => new Link(['link_address'], l['linked_at'], l['active'])),
```

This meant every loaded link's address was the constant garbage value `['link_address']` rather than the real linked account address, breaking any UI or logic that depends on `linkAddress`.

## Fix

Access the property on `l` instead of constructing an array literal:

```js
r.data['links'].map(l => new Link(l['link_address'], l['linked_at'], l['active'])),
```

This matches the `Link` constructor signature `constructor(linkAddress, linkedAt, active)`.

Closes #36

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZWfJfvGVV3o7JxzUHGBMG)_