### PR TITLE
fix: stop OauthToken.accessToken getter from recursing infinitely

### DIFF
--- a/ui/src/helpers/auth.js
+++ b/ui/src/helpers/auth.js
@@ -31,7 +31,7 @@ export class OauthFlow {
 }
 
 export class OauthToken {
-  accessToken
+  _accessToken
   tokenType
   expiresIn
   refreshToken
@@ -45,8 +45,12 @@ export class OauthToken {
     return this.date + this.expiresIn * 1000 > Date.now()
   }
 
+  set accessToken(v) {
+    this._accessToken = v
+  }
+
   get accessToken() {
-    return this.isValid ? this.accessToken : null
+    return this.isValid ? this._accessToken : null
   }
 }
 


### PR DESCRIPTION
## Bug

`OauthToken` in `ui/src/helpers/auth.js` declared a class field `accessToken` and a `get accessToken()` accessor with the same name. The getter's body was `return this.isValid ? this.accessToken : null`, which references itself:

- The class field declaration shadows the accessor, so instances writing `this.token.accessToken = ...` (in `AuthorizationFlowPKCE.callback()` and `ImplicitFlow.callback()`) never actually invoke the getter's expiry check — expired tokens get handed out as valid.
- If the getter path were ever reached, `this.accessToken` inside the getter recurses into itself infinitely, causing a stack overflow.

Either way, the intended "return `null` when expired" behavior never happens.

## Fix

Backed the value with a plain `_accessToken` field (not a `#private` field, since `OauthFlow.save()` relies on `JSON.stringify(this)` and `load()` relies on `Object.assign`, and private fields don't survive that round-trip) and added an explicit setter:

```js
export class OauthToken {
  _accessToken
  tokenType
  expiresIn
  refreshToken
  scope
  date

  get isValid() {
    if (this.date === undefined) {
      return true
    }
    return this.date + this.expiresIn * 1000 > Date.now()
  }

  set accessToken(v) {
    this._accessToken = v
  }

  get accessToken() {
    return this.isValid ? this._accessToken : null
  }
}
```

All existing call sites (`this.token.accessToken = ...` in `auth.js`, and the many `user.token.accessToken` reads across `ui/src`) continue to work unchanged since they go through the public `accessToken` property.

Verified locally (isolated Node script) that:
- a token with no `date` is always considered valid,
- a token with a future expiry returns its value,
- an expired token returns `null` (no more silent bypass, no recursion),
- `JSON.stringify` / `Object.assign` round-trips still preserve and restore the access token correctly.

Closes #37

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZWfJfvGVV3o7JxzUHGBMG)_