### PR TITLE
fix: restrict CORS to known UI origin instead of permissive wildcard

### DIFF
--- a/api/src/guilds/mod.rs
+++ b/api/src/guilds/mod.rs
@@ -8,7 +8,6 @@ use http::StatusCode;
 use lambda_http::tracing::warn;
 use serde_json::{Value, json};
 use std::sync::Arc;
-use tower_http::cors::CorsLayer;
 use twilight_http::Client;
 use twilight_model::guild::Permissions;
 use twilight_model::id::Id;
@@ -26,7 +25,6 @@ pub fn router() -> Router<AppState> {
         .route("/{guild_id}", get(get_guilds_id).post(post_guilds_id))
         .nest("/{guild_id}/verify", verify::controllers::router())
         .nest("/{guild_id}/votes", votes::controllers::router())
-        .layer(CorsLayer::permissive())
 }
 
 async fn _verify_admin(

--- a/api/src/guilds/verify/controllers.rs
+++ b/api/src/guilds/verify/controllers.rs
@@ -11,7 +11,6 @@ use http::StatusCode;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::sync::Arc;
-use tower_http::cors::CorsLayer;
 use twilight_model::id::Id;
 use twilight_model::id::marker::{GuildMarker, RoleMarker};
 use twilight_model::user::CurrentUser;
@@ -23,7 +22,6 @@ pub fn router() -> axum::Router<AppState> {
             "/roles/{role_id}",
             put(put_roles_id).delete(delete_roles_id),
         )
-        .layer(CorsLayer::permissive())
 }
 
 #[derive(Serialize, Deserialize)]

--- a/api/src/guilds/votes/controllers.rs
+++ b/api/src/guilds/votes/controllers.rs
@@ -15,7 +15,6 @@ use lambda_http::aws_lambda_events::apigw::ApiGatewayProxyRequest;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::{HashMap, HashSet};
-use tower_http::cors::CorsLayer;
 use twilight_model::channel::message::{Component, EmojiReactionType};
 use twilight_model::id::Id;
 use twilight_model::id::marker::{ChannelMarker, GuildMarker, MessageMarker, RoleMarker};
@@ -26,7 +25,6 @@ pub fn router() -> axum::Router<AppState> {
         .route("/", post(post_votes))
         .route("/{message_id}", get(get_votes_id))
         .route("/{message_id}/close", post(post_votes_id_close))
-        .layer(CorsLayer::permissive())
 }
 
 #[derive(Serialize, Deserialize)]

--- a/api/src/interactions/mod.rs
+++ b/api/src/interactions/mod.rs
@@ -12,7 +12,6 @@ use http::{HeaderMap, StatusCode};
 use http_body_util::BodyExt;
 use once_cell::sync::Lazy;
 use serde_json::{Value, json};
-use tower_http::cors::CorsLayer;
 use twilight_model::application::command::CommandType;
 use twilight_model::application::interaction::{
     Interaction, InteractionContextType, InteractionData, InteractionType,
@@ -40,7 +39,6 @@ pub fn router() -> axum::Router<AppState> {
         .route_layer(middleware::from_fn(pubkey_middleware))
         .route_layer(middleware::from_fn(user_agent_response_middleware))
         .route("/register", post(register_commands))
-        .layer(CorsLayer::permissive())
 }
 
 pub async fn pubkey_middleware(request: Request, next: Next) -> Result<Response, StatusCode> {

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -2,7 +2,7 @@ use common::dsql::establish_connection;
 use aws_config::BehaviorVersion;
 use axum::body::Body;
 use axum::{http::StatusCode, routing::get, Json, Router};
-use http::Response;
+use http::{Method, Response};
 use lambda_http::{run, tracing, Error};
 use serde_json::{json, Value};
 use sqlx::{Pool, Postgres};
@@ -92,6 +92,20 @@ async fn main() -> Result<(), Error> {
 
     // guilds::tasks::update_guilds(&app_state.discord_bot, &app_state.pg_pool).await;
     setup(app_state.discord_bot.clone());
+
+    // Only allow requests from the first-party UI origin(s). This API trusts the
+    // `Authorization` header for auth, so a permissive `*` origin would let any
+    // website script requests against it using a token it has obtained.
+    let cors = CorsLayer::new()
+        .allow_origin(
+            std::env::var("CORS_ALLOWED_ORIGIN")
+                .expect("env variable `CORS_ALLOWED_ORIGIN` should be set")
+                .parse::<http::HeaderValue>()
+                .expect("CORS_ALLOWED_ORIGIN must be a valid header value (e.g. https://koalabot.uk)"),
+        )
+        .allow_methods([Method::GET, Method::POST, Method::PUT, Method::DELETE])
+        .allow_headers([http::header::AUTHORIZATION, http::header::CONTENT_TYPE]);
+
     let app = Router::new()
         .nest("/users", users::router())
         .nest("/guilds", guilds::router())
@@ -102,7 +116,7 @@ async fn main() -> Result<(), Error> {
         .with_state(app_state)
         .route("/health", get(health_check))
         .route("/bot", get(get_bot_redirect))
-        .layer(CorsLayer::permissive());
+        .layer(cors);
 
     if std::env::var("RUN_LOCAL").is_err() {
         run(app).await

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -98,10 +98,8 @@ async fn main() -> Result<(), Error> {
     // website script requests against it using a token it has obtained.
     let cors = CorsLayer::new()
         .allow_origin(
-            std::env::var("CORS_ALLOWED_ORIGIN")
-                .expect("env variable `CORS_ALLOWED_ORIGIN` should be set")
-                .parse::<http::HeaderValue>()
-                .expect("CORS_ALLOWED_ORIGIN must be a valid header value (e.g. https://koalabot.uk)"),
+            parse_cors_allowed_origin(std::env::var("CORS_ALLOWED_ORIGIN").ok().as_deref())
+                .expect("invalid CORS configuration"),
         )
         .allow_methods([Method::GET, Method::POST, Method::PUT, Method::DELETE])
         .allow_headers([http::header::AUTHORIZATION, http::header::CONTENT_TYPE]);
@@ -127,4 +125,57 @@ async fn main() -> Result<(), Error> {
 
 fn setup(discord_bot: Arc<twilight_http::Client>) {
     meta::setup(discord_bot);
+}
+
+/// Parses the `CORS_ALLOWED_ORIGIN` environment variable into a header value
+/// suitable for `CorsLayer::allow_origin`.
+///
+/// This is extracted out of `main()` so the parsing/validation logic can be
+/// unit tested in isolation. Whether the resulting `CorsLayer` actually
+/// enforces the restriction on real requests (i.e. that browsers sending an
+/// `Origin` header other than the configured one are rejected) is not
+/// unit-testable here since it depends on `tower_http`'s CORS middleware
+/// behaviour and axum's request handling; that should be covered by an
+/// integration/CI-level test that exercises the running service.
+fn parse_cors_allowed_origin(origin: Option<&str>) -> Result<http::HeaderValue, String> {
+    let origin = origin.ok_or_else(|| "env variable `CORS_ALLOWED_ORIGIN` should be set".to_string())?;
+
+    origin.parse::<http::HeaderValue>().map_err(|_| {
+        "CORS_ALLOWED_ORIGIN must be a valid header value (e.g. https://koalabot.uk)".to_string()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_cors_allowed_origin_accepts_valid_origin() {
+        let result = parse_cors_allowed_origin(Some("https://koalabot.uk"));
+
+        assert_eq!(result.expect("should parse").to_str().unwrap(), "https://koalabot.uk");
+    }
+
+    #[test]
+    fn parse_cors_allowed_origin_rejects_missing_value() {
+        let result = parse_cors_allowed_origin(None);
+
+        assert_eq!(
+            result.unwrap_err(),
+            "env variable `CORS_ALLOWED_ORIGIN` should be set"
+        );
+    }
+
+    #[test]
+    fn parse_cors_allowed_origin_rejects_invalid_header_value() {
+        // Carriage-return/newline characters are not permitted in header
+        // values (they would allow header/response splitting), so this must
+        // be rejected rather than silently accepted.
+        let result = parse_cors_allowed_origin(Some("https://koalabot.uk\r\nEvil: 1"));
+
+        assert_eq!(
+            result.unwrap_err(),
+            "CORS_ALLOWED_ORIGIN must be a valid header value (e.g. https://koalabot.uk)"
+        );
+    }
 }

--- a/api/src/meta/guilds.rs
+++ b/api/src/meta/guilds.rs
@@ -15,7 +15,6 @@ use std::ops::{Add, Sub};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::{Instant, sleep};
-use tower_http::cors::CorsLayer;
 use twilight_http::Client;
 use twilight_model::channel::Channel;
 use twilight_model::guild::{Permissions, Role};
@@ -28,7 +27,6 @@ pub fn router() -> Router<AppState> {
     Router::new()
         .route("/", get(get_meta_guilds))
         .route("/{guild_id}", get(get_meta_guilds_id))
-        .layer(CorsLayer::permissive())
 }
 
 pub fn setup(discord_bot: Arc<Client>) {

--- a/api/src/meta/mod.rs
+++ b/api/src/meta/mod.rs
@@ -2,7 +2,6 @@ use crate::AppState;
 use axum::Router;
 use lambda_http::tracing::info;
 use std::sync::Arc;
-use tower_http::cors::CorsLayer;
 use twilight_http::Client;
 
 mod guilds;
@@ -12,7 +11,6 @@ pub fn router() -> Router<AppState> {
     Router::new()
         .nest("/guilds", guilds::router())
         .nest("/users", users::router())
-        .layer(CorsLayer::permissive())
 }
 
 pub fn setup(discord_bot: Arc<Client>) {

--- a/api/src/meta/users.rs
+++ b/api/src/meta/users.rs
@@ -5,7 +5,6 @@ use axum::routing::get;
 use axum::{Extension, Json, Router};
 use http::StatusCode;
 use serde_json::{Value, json};
-use tower_http::cors::CorsLayer;
 use twilight_model::id::Id;
 use twilight_model::id::marker::UserMarker;
 use twilight_model::user::CurrentUser;
@@ -14,7 +13,6 @@ pub fn router() -> Router<AppState> {
     Router::new()
         .route("/@me", get(get_meta_users_me))
         .route("/{user_id}", get(get_meta_users_id))
-        .layer(CorsLayer::permissive())
 }
 
 pub async fn get_meta_users_me(

--- a/api/src/users/link_guilds.rs
+++ b/api/src/users/link_guilds.rs
@@ -9,7 +9,6 @@ use axum::{Extension, Json};
 use http::StatusCode;
 use serde_json::{Value, json};
 use std::sync::Arc;
-use tower_http::cors::CorsLayer;
 use twilight_model::id::Id;
 use twilight_model::id::marker::{GuildMarker, UserMarker};
 use twilight_model::user::CurrentUser;
@@ -22,7 +21,6 @@ pub fn router() -> axum::Router<AppState> {
             "/{guild_id}",
             put(put_link_guilds_id).delete(delete_link_guilds_id),
         )
-        .layer(CorsLayer::permissive())
 }
 
 async fn put_link_guilds_id(

--- a/api/src/users/links.rs
+++ b/api/src/users/links.rs
@@ -16,7 +16,6 @@ use serde_json::json;
 use sha2::Sha256;
 use std::collections::BTreeMap;
 use std::sync::Arc;
-use tower_http::cors::CorsLayer;
 use twilight_model::id::Id;
 use twilight_model::id::marker::UserMarker;
 use twilight_model::user::CurrentUser;
@@ -26,7 +25,6 @@ pub fn router() -> axum::Router<AppState> {
         .route("/", post(post_link))
         .route("/send-email", post(post_send_email))
         .route("/{link_address}", delete(delete_link))
-        .layer(CorsLayer::permissive())
 }
 
 #[derive(Clone, Serialize, Deserialize)]

--- a/api/src/users/mod.rs
+++ b/api/src/users/mod.rs
@@ -11,7 +11,6 @@ use axum::routing::get;
 use axum::{Extension, Json};
 use http::StatusCode;
 use serde_json::{Value, json};
-use tower_http::cors::CorsLayer;
 use twilight_model::id::Id;
 use twilight_model::id::marker::UserMarker;
 use twilight_model::user::CurrentUser;
@@ -23,7 +22,6 @@ pub fn router() -> axum::Router<AppState> {
         .route("/{user_id}", get(get_users_id))
         .nest("/{user_id}/links", links::router())
         .nest("/{user_id}/link_guilds", link_guilds::router())
-        .layer(CorsLayer::permissive())
 }
 
 async fn get_users() -> Json<Value> {

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -35,6 +35,11 @@ module "sqs" {
   deployment_env = var.deployment_env
 }
 
+module "s3" {
+  source = "./modules/data/s3"
+  deployment_env = var.deployment_env
+}
+
 module "lambda" {
   source         = "./modules/compute/lambda"
   deployment_env = var.deployment_env
@@ -45,11 +50,7 @@ module "lambda" {
   dsql_arn = module.dsql.dsql_arn
   sqs_arn = module.sqs.queue_arn
   sqs_url = module.sqs.queue_url
-}
-
-module "s3" {
-  source = "./modules/data/s3"
-  deployment_env = var.deployment_env
+  ui_hostname = module.s3.ui_hostname
 }
 
 module "api" {

--- a/infra/modules/compute/lambda/main.tf
+++ b/infra/modules/compute/lambda/main.tf
@@ -124,6 +124,7 @@ resource "aws_lambda_function" "lambda_function" {
       DSQL_USER                            = var.dsql_user
       DSQL_ENDPOINT                        = var.dsql_endpoint
       SQS_URL                              = var.sqs_url
+      CORS_ALLOWED_ORIGIN                  = "https://${var.ui_hostname}"
     }
   }
 }

--- a/infra/modules/compute/lambda/variables.tf
+++ b/infra/modules/compute/lambda/variables.tf
@@ -10,6 +10,11 @@ variable "discord_public_key" {
   type = string
 }
 
+variable "ui_hostname" {
+  type        = string
+  description = "The hostname for the UI, e.g., 'koalabot.uk'. Used to restrict CORS on the API to the first-party UI origin."
+}
+
 variable "dsql_user" {
   type = string
 }


### PR DESCRIPTION
## Bug

`CorsLayer::permissive()` was applied both globally in `api/src/main.rs` and redundantly on nearly every nested router (`guilds`, `guilds/verify`, `guilds/votes`, `users`, `users/links`, `users/link_guilds`, `meta`, `meta/guilds`, `meta/users`, `interactions`). This sets `Access-Control-Allow-Origin: *` and allows any method/header. Since this API authenticates via a bearer-style `Authorization` header, `*` doesn't leak ambient credentials, but it does let any website script requests against the API using a token it has obtained, and it exposes the full API surface to every origin.

## Fix

- Replace the global `CorsLayer::permissive()` in `api/src/main.rs` with a single `CorsLayer` that:
  - Allows only the origin from the `CORS_ALLOWED_ORIGIN` env var (parsed as a `HeaderValue`, panics at startup if unset/invalid, matching the pattern already used for other required env vars like `DSQL_ENDPOINT`).
  - Allows only `GET`, `POST`, `PUT`, `DELETE`.
  - Allows only the `Authorization` and `Content-Type` headers.
- Remove the duplicate `.layer(CorsLayer::permissive())` calls (and now-unused `tower_http::cors::CorsLayer` imports) from all 10 nested routers, since a single layer at the top level already applies to every route.
- Wire `CORS_ALLOWED_ORIGIN` through Terraform so the Lambda actually has it set: added a `ui_hostname` variable to the `compute/lambda` module and passed `module.s3.ui_hostname` into it from `infra/main.tf`, matching the existing `koalabot.uk` / `{env}.koalabot.uk` convention already used elsewhere (e.g. `interactions::get_url()` and the `api-gateway` module's `ui_hostname`).

## Test plan
- [x] `cargo check -p api` compiles cleanly with no warnings.
- [ ] Deploy to dev and confirm the UI can still make authenticated cross-origin requests, and that a request from a non-allow-listed origin is rejected by the browser's CORS check.

Closes #32


---
_Generated by [Claude Code](https://claude.ai/code/session_01EZWfJfvGVV3o7JxzUHGBMG)_