### PR TITLE
fix(api): add backoff and correct error logging in audit() retry loop

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 
 [dependencies]
 lambda_http = { workspace = true }
-tokio = { workspace = true, features = ["macros"] }
+tokio = { workspace = true, features = ["macros", "time"] }
 tower-http = { workspace = true, features = ["cors", "auth"] }
 axum = { workspace = true }
 http = { workspace = true }

--- a/api/src/audit.rs
+++ b/api/src/audit.rs
@@ -1,44 +1,75 @@
 use aws_sdk_sqs::types::MessageAttributeValue;
 use lambda_http::tracing::error;
 use serde::{Deserialize, Serialize};
+use tokio::time::{sleep, Duration};
 pub use common::audit::AuditMessage;
+
+const MAX_ATTEMPTS: u32 = 3;
 
 pub async fn audit<T>(audit: AuditMessage<T>, sqs: &aws_sdk_sqs::Client)
 where
     T: Serialize + for<'de> Deserialize<'de>,
 {
     let queue_url = std::env::var("SQS_URL").expect("SQS_URL must be set");
-    
-    let new_audit = AuditMessage::new(
-        audit.event,
-        audit.user_id,
-        audit.guild_id,
-        audit.data.old_data.map(|v: T| serde_json::to_string(&v).unwrap()),
-        audit.data.new_data.map(|v: T| serde_json::to_string(&v).unwrap())
-    );
 
-    let mut attempts = 0;
-    
-    loop {
-        attempts += 1;
+    let old_data = match audit.data.old_data.map(|v: T| serde_json::to_string(&v)) {
+        Some(Ok(s)) => Some(s),
+        Some(Err(e)) => {
+            error!("Failed to serialize audit old_data, dropping audit: {}", e);
+            return;
+        }
+        None => None,
+    };
+    let new_data = match audit.data.new_data.map(|v: T| serde_json::to_string(&v)) {
+        Some(Ok(s)) => Some(s),
+        Some(Err(e)) => {
+            error!("Failed to serialize audit new_data, dropping audit: {}", e);
+            return;
+        }
+        None => None,
+    };
 
+    let new_audit = AuditMessage::new(audit.event, audit.user_id, audit.guild_id, old_data, new_data);
+
+    let body = match serde_json::to_string(&new_audit) {
+        Ok(b) => b,
+        Err(e) => {
+            error!("Failed to serialize audit message, dropping audit: {}", e);
+            return;
+        }
+    };
+
+    let kind_attribute = match MessageAttributeValue::builder()
+        .data_type("String")
+        .string_value("audit")
+        .build()
+    {
+        Ok(a) => a,
+        Err(e) => {
+            error!("Failed to build audit message attribute, dropping audit: {}", e);
+            return;
+        }
+    };
+
+    for attempt in 1..=MAX_ATTEMPTS {
         match sqs
             .send_message()
             .queue_url(&queue_url)
-            .message_attributes("kind", MessageAttributeValue::builder()
-                .data_type("String")
-                .string_value("audit")
-                .build().unwrap())
-            .message_body(serde_json::to_string(&new_audit).unwrap())
+            .message_attributes("kind", kind_attribute.clone())
+            .message_body(&body)
             .send()
-            .await {
-            Ok(_) => break,
+            .await
+        {
+            Ok(_) => return,
             Err(e) => {
-                if attempts >= 3 {
-                    error!("Failed to send audit to SQS after 3 attempts {}", &new_audit);
-                    break;
+                if attempt >= MAX_ATTEMPTS {
+                    error!(
+                        "Failed to send audit to SQS after {} attempts, dropping audit: {} (message: {})",
+                        MAX_ATTEMPTS, e, &new_audit
+                    );
                 } else {
-                    error!("Failed to send audit to SQS, retrying... {}", e);
+                    error!("Failed to send audit to SQS (attempt {}/{}), retrying... {}", attempt, MAX_ATTEMPTS, e);
+                    sleep(Duration::from_millis(100 * 2u64.pow(attempt))).await;
                 }
             }
         }


### PR DESCRIPTION
## Bug

`audit()` in `api/src/audit.rs` sends audit events to SQS with a 3-attempt retry loop that had several problems:

- **No backoff between retries** — on a throttling/network error it spun three times back-to-back with zero delay, adding latency to the awaiting request without giving the dependency any breathing room.
- **Wrong info logged on final failure** — the `attempts >= 3` branch logged the serialized `new_audit` message but never logged the actual error `e`, discarding the real failure cause exactly when it mattered most.
- **Panics on serialization/build failure** — `serde_json::to_string(...).unwrap()` and `.build().unwrap()` could panic inside a function whose entire purpose is best-effort side-channel logging.

## Fix

- Added exponential backoff (`100ms * 2^attempt`) between retry attempts using `tokio::time::sleep`.
- Every attempt now logs the real error `e`; the final failed attempt logs the error *and* the dropped message, at `error!` level.
- Replaced the `unwrap()` calls on serialization/attribute-building with explicit error handling that logs and returns instead of panicking.
- Added the `time` feature to the `api` crate's `tokio` dependency (required for `tokio::time::sleep`).

`cargo check -p api` passes with no warnings.

Closes #29

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZWfJfvGVV3o7JxzUHGBMG)_