### PR TITLE
fix: avoid panic in post_link when guild user_links has no entry for user

### DIFF
--- a/api/src/users/links.rs
+++ b/api/src/users/links.rs
@@ -126,8 +126,8 @@ async fn post_link(
         guild
             .verify
             .user_links
-            .get_mut(&user_id)
-            .unwrap()
+            .entry(user_id)
+            .or_default()
             .push(new_link.clone());
         guild.save(&app_state.pg_pool).await;
     }


### PR DESCRIPTION
## Bug

In `api/src/users/links.rs`, `post_link` called:

```rust
guild.verify.user_links.get_mut(&user_id).unwrap().push(new_link.clone());
```

A user can have a `LinkGuild` entry without the corresponding guild's `verify.user_links` map containing an entry for them (e.g. first-time link to that guild, or drift between the two). In that case `get_mut(&user_id)` returns `None` and `.unwrap()` panics — after Discord roles have already been granted via `add_guild_member_role`, and potentially after earlier guilds in the loop have already been saved. This leaves Discord role state and the DB inconsistent, and the user's `links` row is never updated since `user_model.save` (further down) is never reached.

## Fix

Use the `entry` API so a missing `user_links` entry is created instead of causing a panic:

```rust
guild
    .verify
    .user_links
    .entry(user_id)
    .or_default()
    .push(new_link.clone());
```

`user_links` is a `HashMap<Id<UserMarker>, Vec<Link>>`, so `Vec::default()` gives an empty vec to push onto, matching how new entries are created elsewhere (e.g. `api/src/users/link_guilds.rs`).

This is a minimal, targeted fix for the panic. Broader concerns mentioned in the issue (save() ignoring errors, from_db().unwrap() panics, restructuring to compute all Discord mutations before persisting) are tracked separately and are out of scope here.

Verified with `cargo check -p api` — compiles cleanly.

Closes #25

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZWfJfvGVV3o7JxzUHGBMG)_