### PR TITLE
fix(api): validate channel_id belongs to guild in post_votes

### DIFF
--- a/api/src/guilds/votes/controllers.rs
+++ b/api/src/guilds/votes/controllers.rs
@@ -1,7 +1,7 @@
-use crate::discord::{create_message, ise, update_message};
+use crate::discord::{create_message, get_guild_channels, ise, update_message};
 use crate::guilds::models::Guild;
 use crate::guilds::votes::models::{RoleListType, VoteOption, VoteVote};
-use crate::guilds::votes::utils::{VoteOptionComponent, group_to_rows};
+use crate::guilds::votes::utils::{VoteOptionComponent, channel_belongs_to_guild, group_to_rows};
 use crate::{AppState, utils};
 use aws_sdk_scheduler::types::{FlexibleTimeWindow, FlexibleTimeWindowMode, Target};
 use axum::extract::{Path, State};
@@ -66,6 +66,12 @@ async fn post_votes(
 ) -> Result<Json<Value>, StatusCode> {
     if !utils::is_client_admin_guild(guild_id, &current_user, &app_state.discord_bot).await? {
         return Err(StatusCode::FORBIDDEN);
+    }
+
+    let guild_channels = get_guild_channels(guild_id, &app_state.discord_bot).await?;
+    let guild_channel_ids: Vec<_> = guild_channels.iter().map(|c| c.id).collect();
+    if !channel_belongs_to_guild(vote_req.channel_id, &guild_channel_ids) {
+        return Err(StatusCode::BAD_REQUEST);
     }
 
     let message = create_message(

--- a/api/src/guilds/votes/utils.rs
+++ b/api/src/guilds/votes/utils.rs
@@ -1,6 +1,8 @@
 use http::StatusCode;
 use twilight_model::channel::message::component::{ActionRow, Button, ButtonStyle};
 use twilight_model::channel::message::{Component, EmojiReactionType};
+use twilight_model::id::Id;
+use twilight_model::id::marker::ChannelMarker;
 
 pub trait VoteOptionComponent {
     fn emoji(&self) -> &Option<EmojiReactionType>;
@@ -47,4 +49,46 @@ pub fn group_to_rows(components: Vec<Component>) -> Result<Vec<Component>, Statu
         return Err(StatusCode::BAD_REQUEST);
     }
     Ok(rows)
+}
+
+/// Returns whether `channel_id` is one of the channels belonging to a guild.
+///
+/// `guild_channel_ids` should be the IDs of the channels fetched for the
+/// guild in question (e.g. via `discord::get_guild_channels`). This is used
+/// to guard against a caller-supplied `channel_id` that belongs to a
+/// different guild than the one the caller was authorized against.
+pub fn channel_belongs_to_guild(
+    channel_id: Id<ChannelMarker>,
+    guild_channel_ids: &[Id<ChannelMarker>],
+) -> bool {
+    guild_channel_ids.contains(&channel_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn channel_belongs_to_guild_accepts_channel_in_guild() {
+        let target = Id::new(123);
+        let guild_channel_ids = vec![Id::new(111), Id::new(123), Id::new(222)];
+
+        assert!(channel_belongs_to_guild(target, &guild_channel_ids));
+    }
+
+    #[test]
+    fn channel_belongs_to_guild_rejects_channel_from_another_guild() {
+        let foreign_channel = Id::new(999);
+        let guild_channel_ids = vec![Id::new(111), Id::new(123), Id::new(222)];
+
+        assert!(!channel_belongs_to_guild(foreign_channel, &guild_channel_ids));
+    }
+
+    #[test]
+    fn channel_belongs_to_guild_rejects_when_guild_has_no_channels() {
+        let target = Id::new(123);
+        let guild_channel_ids: Vec<Id<ChannelMarker>> = vec![];
+
+        assert!(!channel_belongs_to_guild(target, &guild_channel_ids));
+    }
 }


### PR DESCRIPTION
## Bug

`post_votes` (`api/src/guilds/votes/controllers.rs`) checked that the requester is an admin of `guild_id` (from the path), but posted the message to `vote_req.channel_id` (from the request body) without ever verifying that channel belongs to that guild. An admin of any single guild the bot is in could supply an arbitrary `channel_id` belonging to a completely different guild and have the bot post spoofed content (`# {title}\n{description}`) into it — a cross-guild privilege escalation / message spoofing issue.

## Fix

After the existing `is_client_admin_guild` check, the handler now fetches the guild's actual channels via the existing `discord::get_guild_channels` helper and validates that `vote_req.channel_id` is one of them, returning `400 Bad Request` if not.

The membership check itself was extracted into a small, pure, testable helper — `channel_belongs_to_guild(channel_id, guild_channel_ids) -> bool` in `api/src/guilds/votes/utils.rs` — decoupled from the Discord API so it can be unit tested without mocking HTTP calls.

## Test

Added `#[test]` unit tests in `api/src/guilds/votes/utils.rs` covering `channel_belongs_to_guild`:
- accepts a channel that is present in the guild's channel list
- rejects a channel belonging to a different guild (not in the list)
- rejects when the guild has no channels at all

Ran `cargo test -p api channel_belongs_to_guild` (3 passed) and `cargo check -p api` (clean).

Closes #24

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZWfJfvGVV3o7JxzUHGBMG)_