### PR TITLE
fix(consumer): don't panic the whole SQS batch on a malformed audit message

### DIFF
--- a/consumer/src/audit/consumer.rs
+++ b/consumer/src/audit/consumer.rs
@@ -1,21 +1,35 @@
 use aws_lambda_events::sqs::SqsMessage;
 use common::audit::AuditMessage;
+use lambda_runtime::Error;
 use crate::AppState;
 use crate::audit::models::Audit;
 
-pub async fn consume(message: SqsMessage, state: &AppState) {
-    let audit: Audit = serde_json::from_str::<AuditMessage<String>>(message.body.unwrap().as_str()).unwrap().into();
+/// Parse an SQS message body into an `Audit`, without performing any I/O.
+///
+/// This is split out from [`consume`] so a malformed/missing body results in
+/// an `Err` that the caller can report as a single failed batch item, rather
+/// than panicking and taking down the whole Lambda invocation (and with it,
+/// every other message in the batch).
+fn parse_audit(message: &SqsMessage) -> Result<Audit, Error> {
+    let body = message.body.as_deref().ok_or("missing SQS message body")?;
+    let audit_message = serde_json::from_str::<AuditMessage<String>>(body)?;
+    Ok(audit_message.into())
+}
+
+pub async fn consume(message: SqsMessage, state: &AppState) -> Result<(), Error> {
+    let audit = parse_audit(&message)?;
     audit.save(&state.pg_pool).await;
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-    use serde_json::Error;
+    use serde_json::Error as JsonError;
     use tracing::{debug};
     use super::*;
 
     #[test]
-    fn test_decode() -> Result<(), Error> {
+    fn test_decode() -> Result<(), JsonError> {
         let mut example_sqs_message = SqsMessage::default();
         example_sqs_message.body = Some(r#"{"event":"update_link_guilds","user_id":"228541431483072513","guild_id":"590643624358969350","data":{"old_data":"[{\"guild_id\":\"863362407183286302\",\"enabled\":true}]","new_data":"[{\"guild_id\":\"863362407183286302\",\"enabled\":true},{\"guild_id\":\"590643624358969350\",\"enabled\":true}]"}}"#.to_string());
         let audit_msg = serde_json::from_str::<AuditMessage<String>>(example_sqs_message.body.unwrap().as_str())?;
@@ -26,4 +40,39 @@ mod tests {
         Ok(())
     }
 
+    /// Regression test for a single malformed message stalling/re-delivering
+    /// the whole SQS batch forever: `parse_audit` must return an `Err`
+    /// instead of panicking when the body isn't valid JSON for `AuditMessage`.
+    #[test]
+    fn test_parse_audit_malformed_json_returns_error_not_panic() {
+        let mut malformed_message = SqsMessage::default();
+        malformed_message.body = Some("this is not valid json at all".to_string());
+
+        let result = parse_audit(&malformed_message);
+
+        assert!(result.is_err(), "malformed message body should be reported as an error, not panic");
+    }
+
+    /// Regression test: a message with no body at all must also be handled
+    /// gracefully rather than panicking on `.unwrap()`.
+    #[test]
+    fn test_parse_audit_missing_body_returns_error_not_panic() {
+        let missing_body_message = SqsMessage::default();
+
+        let result = parse_audit(&missing_body_message);
+
+        assert!(result.is_err(), "missing message body should be reported as an error, not panic");
+    }
+
+    /// A well-formed message in the same batch as a malformed one must still
+    /// be parsed successfully - partial batch failures should not affect it.
+    #[test]
+    fn test_parse_audit_well_formed_message_succeeds() {
+        let mut well_formed_message = SqsMessage::default();
+        well_formed_message.body = Some(r#"{"event":"update_link_guilds","user_id":"228541431483072513","guild_id":"590643624358969350","data":{"old_data":"[{\"guild_id\":\"863362407183286302\",\"enabled\":true}]","new_data":"[{\"guild_id\":\"863362407183286302\",\"enabled\":true},{\"guild_id\":\"590643624358969350\",\"enabled\":true}]"}}"#.to_string());
+
+        let result = parse_audit(&well_formed_message);
+
+        assert!(result.is_ok(), "well-formed message should still parse successfully");
+    }
 }

--- a/consumer/src/main.rs
+++ b/consumer/src/main.rs
@@ -1,6 +1,6 @@
 mod audit;
 
-use aws_lambda_events::event::sqs::SqsEvent;
+use aws_lambda_events::event::sqs::{SqsBatchResponse, SqsEvent};
 use aws_sdk_dsql::config::BehaviorVersion;
 use lambda_runtime::{run, service_fn, Error, LambdaEvent};
 use sqlx::{Pool, Postgres};
@@ -12,13 +12,24 @@ pub struct AppState {
     pub pg_pool: Pool<Postgres>,
 }
 
-async fn function_handler(event: LambdaEvent<SqsEvent>, state: &AppState) -> Result<(), Error> {
+async fn function_handler(event: LambdaEvent<SqsEvent>, state: &AppState) -> Result<SqsBatchResponse, Error> {
+    let mut response = SqsBatchResponse::default();
+
     for message in event.payload.records {
+        let message_id = message.message_id.clone().unwrap_or_default();
         info!("Message body: {:?}", message.body);
         match message.message_attributes.get("kind") {
             Some(attr) => {
                 match attr.string_value.as_deref() {
-                    Some("audit") => audit::consume(message.clone(), state).await,
+                    Some("audit") => {
+                        if let Err(e) = audit::consume(message.clone(), state).await {
+                            // Report only this message as failed so the rest of the
+                            // batch can still succeed, instead of panicking and
+                            // causing the whole batch to be redelivered forever.
+                            error!("Failed to process audit message {}: {}", message_id, e);
+                            response.add_failure(message_id);
+                        }
+                    }
                     _ => error!("Unknown message type: {}; body: {}", attr.string_value.as_deref().unwrap_or_default(), message.body.as_deref().unwrap_or_default())
                 }
 
@@ -27,7 +38,7 @@ async fn function_handler(event: LambdaEvent<SqsEvent>, state: &AppState) -> Res
         }
     }
 
-    Ok(())
+    Ok(response)
 }
 
 #[tokio::main]

--- a/infra/modules/compute/lambda/main.tf
+++ b/infra/modules/compute/lambda/main.tf
@@ -209,4 +209,9 @@ resource "aws_lambda_function" "lambda_consumer" {
 resource "aws_lambda_event_source_mapping" "example_mapping" {
   event_source_arn = var.sqs_arn
   function_name    = aws_lambda_function.lambda_consumer.function_name
+
+  # Let the consumer report individual failed messages (batch_item_failures)
+  # instead of the whole batch being retried/redelivered when a single
+  # message fails to process (e.g. malformed body/JSON).
+  function_response_types = ["ReportBatchItemFailures"]
 }


### PR DESCRIPTION
## Bug

`consumer/src/audit/consumer.rs` `consume()` used `.unwrap()` on both the SQS message body and its JSON deserialization:

```rust
pub async fn consume(message: SqsMessage, state: &AppState) {
    let audit: Audit = serde_json::from_str::<AuditMessage<String>>(message.body.unwrap().as_str())
        .unwrap()
        .into();
    audit.save(&state.pg_pool).await;
}
```

A single malformed/missing-body message in an SQS batch would panic the Lambda invocation. Since `function_handler` returned `Ok(())` for the whole batch or propagated the panic, **the entire batch** (including otherwise well-formed messages) was marked failed and redelivered — a poison message loop that blocks audit processing for all guilds until it hits the DLQ / max-receive count.

## Fix

- Added a pure `parse_audit()` helper in `consumer/src/audit/consumer.rs` that turns a missing body or invalid JSON into an `Err` instead of panicking.
- `consume()` is now fallible (`Result<(), Error>`), propagating parse failures via `?` instead of unwrapping.
- `function_handler` in `consumer/src/main.rs` now returns `Result<SqsBatchResponse, Error>` and calls `response.add_failure(message_id)` only for the message(s) that actually failed, so well-formed messages in the same batch still succeed and get deleted from the queue.
- Enabled `function_response_types = ["ReportBatchItemFailures"]` on the `aws_lambda_event_source_mapping` for the consumer Lambda in `infra/modules/compute/lambda/main.tf` — required for Lambda to honor partial batch responses (without it, AWS falls back to retrying the whole batch on any reported failure).

## Test

Added regression tests in `consumer/src/audit/consumer.rs` (following the existing `test_decode` convention):
- `test_parse_audit_malformed_json_returns_error_not_panic` — invalid JSON body returns `Err`, no panic.
- `test_parse_audit_missing_body_returns_error_not_panic` — missing body returns `Err`, no panic.
- `test_parse_audit_well_formed_message_succeeds` — a well-formed message (as would appear alongside a malformed one in the same batch) still parses successfully.

`cargo test -p consumer` (4 tests) and `cargo check -p consumer` both pass cleanly.

Closes #30

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZWfJfvGVV3o7JxzUHGBMG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message processing so a single bad record no longer fails the entire batch.
  * Invalid or missing message content is now handled gracefully instead of causing a crash.
  * Successfully processed messages can now be acknowledged even when some items in the batch fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->