### PR TITLE
fix(api): return 404 instead of panicking in get_votes_id and put_roles_id lookups

### DIFF
--- a/api/src/guilds/verify/controllers.rs
+++ b/api/src/guilds/verify/controllers.rs
@@ -68,13 +68,14 @@ async fn put_roles_id(
     guild.save(&app_state.pg_pool).await;
 
     Ok(Json(json!(
-        guild
-            .verify
-            .roles
-            .iter()
-            .find(|r| r.role_id == role_id)
-            .unwrap()
+        find_role(&guild.verify.roles, role_id).ok_or(StatusCode::NOT_FOUND)?
     )))
+}
+
+/// Locates a verify role by role id, without panicking when the role id
+/// isn't present.
+fn find_role(roles: &[VerifyRole], role_id: Id<RoleMarker>) -> Option<&VerifyRole> {
+    roles.iter().find(|r| r.role_id == role_id)
 }
 
 async fn delete_roles_id(
@@ -167,4 +168,47 @@ async fn post_recon(
     guild.save(&app_state.pg_pool).await;
 
     Ok(StatusCode::NO_CONTENT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_role(role_id: u64) -> VerifyRole {
+        VerifyRole {
+            role_id: Id::new(role_id),
+            pattern: "pattern".to_string(),
+            members: 0,
+        }
+    }
+
+    #[test]
+    fn find_role_returns_none_for_missing_role_id() {
+        let roles = vec![sample_role(1), sample_role(2)];
+
+        assert!(find_role(&roles, Id::new(999)).is_none());
+    }
+
+    #[test]
+    fn find_role_returns_some_for_existing_role_id() {
+        let roles = vec![sample_role(1), sample_role(2)];
+
+        let found = find_role(&roles, Id::new(2)).expect("role should be found");
+        assert_eq!(found.role_id, Id::new(2));
+    }
+
+    /// Regression test for issue #26: put_roles_id used to `.unwrap()` the
+    /// result of `find` when re-reading back the just-pushed role, which
+    /// panics (and surfaces as a 500) if the role isn't present. This
+    /// asserts the handler's lookup path now converts a missing role into
+    /// a NOT_FOUND result instead of panicking.
+    #[test]
+    fn missing_role_maps_to_404_instead_of_panicking() {
+        let roles = vec![sample_role(1)];
+
+        let result: Result<&VerifyRole, StatusCode> =
+            find_role(&roles, Id::new(404)).ok_or(StatusCode::NOT_FOUND);
+
+        assert_eq!(result.err(), Some(StatusCode::NOT_FOUND));
+    }
 }

--- a/api/src/guilds/votes/controllers.rs
+++ b/api/src/guilds/votes/controllers.rs
@@ -157,6 +157,12 @@ async fn post_votes(
     Ok(Json(json!(new_vote)))
 }
 
+/// Locates a vote by message id within a guild's votes, without panicking
+/// when the message id isn't present.
+fn find_vote(votes: &[VoteVote], message_id: Id<MessageMarker>) -> Option<&VoteVote> {
+    votes.iter().find(|v| v.message_id == message_id)
+}
+
 async fn get_votes_id(
     Path((guild_id, message_id)): Path<(Id<GuildMarker>, Id<MessageMarker>)>,
     Extension(current_user): Extension<CurrentUser>,
@@ -167,12 +173,7 @@ async fn get_votes_id(
     }
 
     let guild = Guild::from_db(guild_id, &app_state.pg_pool).await.unwrap();
-    let vote: &VoteVote = guild
-        .vote
-        .votes
-        .iter()
-        .find(|v| v.message_id == message_id)
-        .unwrap();
+    let vote = find_vote(&guild.vote.votes, message_id).ok_or(StatusCode::NOT_FOUND)?;
     Ok(Json(json!(vote)))
 }
 
@@ -231,4 +232,54 @@ async fn post_votes_id_close(
     .await?;
 
     Ok(Json(json!(vote)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_vote(message_id: u64) -> VoteVote {
+        VoteVote {
+            message_id: Id::new(message_id),
+            title: "title".to_string(),
+            description: "description".to_string(),
+            options: vec![],
+            channel_id: Id::new(1),
+            close_at: None,
+            open: true,
+            role_list: HashSet::new(),
+            role_list_type: RoleListType::Blacklist,
+            is_multi_select: true,
+        }
+    }
+
+    #[test]
+    fn find_vote_returns_none_for_missing_message_id() {
+        let votes = vec![sample_vote(1), sample_vote(2)];
+
+        assert!(find_vote(&votes, Id::new(999)).is_none());
+    }
+
+    #[test]
+    fn find_vote_returns_some_for_existing_message_id() {
+        let votes = vec![sample_vote(1), sample_vote(2)];
+
+        let found = find_vote(&votes, Id::new(2)).expect("vote should be found");
+        assert_eq!(found.message_id, Id::new(2));
+    }
+
+    /// Regression test for issue #26: get_votes_id used to `.unwrap()` the
+    /// result of `find`, which panics (and surfaces as a 500) when the
+    /// message_id isn't a known vote. This asserts the handler's lookup
+    /// path now converts a missing vote into a NOT_FOUND result instead
+    /// of panicking.
+    #[test]
+    fn missing_vote_maps_to_404_instead_of_panicking() {
+        let votes = vec![sample_vote(1)];
+
+        let result: Result<&VoteVote, StatusCode> =
+            find_vote(&votes, Id::new(404)).ok_or(StatusCode::NOT_FOUND);
+
+        assert_eq!(result.err(), Some(StatusCode::NOT_FOUND));
+    }
 }


### PR DESCRIPTION
## Bug
`GET /guilds/{guild_id}/votes/{message_id}` (`get_votes_id` in `api/src/guilds/votes/controllers.rs`) and the response lookup in `PUT /guilds/{guild_id}/verify/roles/{role_id}` (`put_roles_id` in `api/src/guilds/verify/controllers.rs`) both used `.unwrap()` on the result of `.find(...)` to locate a specific vote/role. When the id isn't present, this panics and surfaces as a 500 instead of a proper 404 — inconsistent with `post_votes_id_close`, which already handles the same situation correctly via `match ... None => NOT_FOUND`.

## Fix
- Replaced both `.unwrap()` calls with `.ok_or(StatusCode::NOT_FOUND)?`, matching the existing convention used elsewhere in the `api` crate.
- Extracted the lookups into small, pure helper functions (`find_vote` in `votes/controllers.rs`, `find_role` in `verify/controllers.rs`) so the fixed not-found behavior can be unit tested without needing a live DB or Discord/AWS clients.

## Tests
Added `#[cfg(test)] mod tests` unit tests in both files exercising `find_vote`/`find_role` directly:
- returns `None`/`Some` correctly for missing/present ids
- explicitly asserts the "missing id" case maps to `Err(StatusCode::NOT_FOUND)` via `.ok_or(StatusCode::NOT_FOUND)`, i.e. the exact fix for this bug, instead of panicking

**Not covered**: a full HTTP-level integration test through the actual `get_votes_id`/`put_roles_id` axum handlers, since those require a live Postgres DB and Discord/AWS clients not available in this environment. The unit tests isolate and cover the specific lookup logic that was the source of the panic.

Verified with `cargo check -p api` (clean) and `cargo test -p api` (all 6 tests pass, including the 6 new ones).

Closes #26

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZWfJfvGVV3o7JxzUHGBMG)_