### PR TITLE
fix(api): derive verify role member counts from user_links instead of hand-rolled counters

### DIFF
--- a/api/src/guilds/verify/controllers.rs
+++ b/api/src/guilds/verify/controllers.rs
@@ -47,7 +47,7 @@ async fn put_roles_id(
         remove_existing_role(&mut guild, role_id, &app_state).await?;
     }
 
-    let mut new_role = VerifyRole {
+    let new_role = VerifyRole {
         role_id,
         pattern: put_role_request.pattern,
         ..Default::default()
@@ -60,11 +60,13 @@ async fn put_roles_id(
                     .await;
             if !(r.is_err() && r.err().unwrap().eq(&StatusCode::NOT_FOUND)) {
                 r?;
-                new_role.members += 1;
             }
         }
     }
     guild.verify.roles.push(new_role);
+    // `members` is derived from `user_links`, not hand-incremented, so it
+    // can never drift out of sync with the other role/link handlers.
+    guild.verify.recompute_role_members();
     guild.save(&app_state.pg_pool).await;
 
     Ok(Json(json!(
@@ -135,12 +137,11 @@ async fn post_recon(
     let mut guild = Guild::from_db(guild_id, &app_state.pg_pool).await.unwrap();
     let Verify { roles, user_links } = &mut guild.verify;
 
-    for role in roles {
-        role.members = 0;
+    for role in roles.iter() {
         for (user_id, links) in &*user_links {
             if link_arr_match(links, &role.pattern) {
                 let r = add_guild_member_role(
-                    guild.guild_id,
+                    guild_id,
                     *user_id,
                     role.role_id,
                     &app_state.discord_bot,
@@ -148,11 +149,10 @@ async fn post_recon(
                 .await;
                 if !(r.is_err() && r.err().unwrap().eq(&StatusCode::NOT_FOUND)) {
                     r?;
-                    role.members += 1;
                 }
             } else {
                 let r = remove_guild_member_role(
-                    guild.guild_id,
+                    guild_id,
                     *user_id,
                     role.role_id,
                     &app_state.discord_bot,
@@ -164,6 +164,10 @@ async fn post_recon(
             }
         }
     }
+    // Recompute every role's `members` from `user_links` in one place so
+    // recon uses exactly the same counting logic as put_roles_id/add/remove,
+    // instead of a manual counter that can disagree with them.
+    guild.verify.recompute_role_members();
     guild.save(&app_state.pg_pool).await;
 
     Ok(StatusCode::NO_CONTENT)

--- a/api/src/guilds/verify/models.rs
+++ b/api/src/guilds/verify/models.rs
@@ -1,4 +1,5 @@
 use crate::users::models::Link;
+use crate::users::utils::link_arr_match;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::hash::Hash;
@@ -33,5 +34,166 @@ impl Hash for VerifyRole {
 pub struct Verify {
     pub roles: Vec<VerifyRole>,
     pub user_links: HashMap<Id<UserMarker>, Vec<Link>>,
+}
+
+impl Verify {
+    /// Recomputes `members` for every role from `user_links`, which is the
+    /// single source of truth for who currently holds a verify role.
+    ///
+    /// This must be called after any mutation of `user_links` (link add,
+    /// link remove, guild link/unlink, role add, recon, ...) instead of
+    /// hand-incrementing/decrementing `role.members`, so all call sites stay
+    /// consistent and counts can never drift. A member is counted at most
+    /// once per role even if they have multiple active links that match the
+    /// role's pattern.
+    pub fn recompute_role_members(&mut self) {
+        let user_links = &self.user_links;
+        for role in &mut self.roles {
+            role.members = user_links
+                .values()
+                .filter(|links| link_arr_match(links, &role.pattern))
+                .count() as u32;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::users::models::Link;
+
+    fn active_link(address: &str) -> Link {
+        Link {
+            link_address: address.to_string(),
+            linked_at: 0,
+            active: true,
+        }
+    }
+
+    fn inactive_link(address: &str) -> Link {
+        Link {
+            link_address: address.to_string(),
+            linked_at: 0,
+            active: false,
+        }
+    }
+
+    fn role(pattern: &str) -> VerifyRole {
+        VerifyRole {
+            role_id: Id::new(1),
+            pattern: pattern.to_string(),
+            members: 0,
+        }
+    }
+
+    /// Regression test for koalabotuk/kb2#28: re-adding a link a user
+    /// previously had (remove-then-re-add, as `post_link` does) must not
+    /// inflate the role's member count. Recomputing from `user_links` after
+    /// every mutation keeps the count at 1, not 2.
+    #[test]
+    fn recompute_role_members_does_not_double_count_on_relink() {
+        let mut verify = Verify {
+            roles: vec![role(r"@example\.com$")],
+            user_links: HashMap::new(),
+        };
+        let user_id: Id<UserMarker> = Id::new(1);
+
+        // First link is added.
+        verify
+            .user_links
+            .insert(user_id, vec![active_link("a@example.com")]);
+        verify.recompute_role_members();
+        assert_eq!(verify.roles[0].members, 1);
+
+        // Simulate `post_link`'s remove-then-re-add of the *same* address
+        // (e.g. the user re-links an email they already had).
+        let links = verify.user_links.get_mut(&user_id).unwrap();
+        links.retain(|l| l.link_address != "a@example.com");
+        links.push(active_link("a@example.com"));
+        verify.recompute_role_members();
+
+        // Previously this would have been 2 because callers incremented
+        // `role.members` on every add without checking prior state.
+        assert_eq!(verify.roles[0].members, 1);
+    }
+
+    /// A member with several active links that all match the same role
+    /// pattern must still only count once — one member, one seat.
+    #[test]
+    fn recompute_role_members_dedupes_multiple_matching_links_for_one_user() {
+        let mut verify = Verify {
+            roles: vec![role(r"@example\.com$")],
+            user_links: HashMap::new(),
+        };
+        let user_id: Id<UserMarker> = Id::new(1);
+        verify.user_links.insert(
+            user_id,
+            vec![
+                active_link("a@example.com"),
+                active_link("b@example.com"),
+            ],
+        );
+
+        verify.recompute_role_members();
+
+        assert_eq!(verify.roles[0].members, 1);
+    }
+
+    /// Inactive (superseded) links must not count towards membership, and
+    /// removing a user's only active link drops the count back to 0 —
+    /// mirroring what `delete_link`/`delete_link_guilds_id` need.
+    #[test]
+    fn recompute_role_members_ignores_inactive_links_and_tracks_removal() {
+        let mut verify = Verify {
+            roles: vec![role(r"@example\.com$")],
+            user_links: HashMap::new(),
+        };
+        let user_id: Id<UserMarker> = Id::new(1);
+        verify
+            .user_links
+            .insert(user_id, vec![active_link("a@example.com")]);
+        verify.recompute_role_members();
+        assert_eq!(verify.roles[0].members, 1);
+
+        // Link gets deactivated (soft removal), as `delete_link` does.
+        verify
+            .user_links
+            .insert(user_id, vec![inactive_link("a@example.com")]);
+        verify.recompute_role_members();
+        assert_eq!(verify.roles[0].members, 0);
+    }
+
+    /// Two different roles derive independent, correct counts from the same
+    /// shared `user_links` map — this is the "recon vs put_roles_id vs
+    /// add/remove" consistency the issue calls out: every code path now
+    /// goes through the same recompute logic instead of hand-rolled
+    /// increment/decrement guards.
+    #[test]
+    fn recompute_role_members_keeps_multiple_roles_consistent() {
+        let mut verify = Verify {
+            roles: vec![role(r"@example\.com$"), role(r"@other\.com$")],
+            user_links: HashMap::new(),
+        };
+        let user_a: Id<UserMarker> = Id::new(1);
+        let user_b: Id<UserMarker> = Id::new(2);
+        verify
+            .user_links
+            .insert(user_a, vec![active_link("a@example.com")]);
+        verify
+            .user_links
+            .insert(user_b, vec![active_link("b@other.com")]);
+
+        verify.recompute_role_members();
+
+        assert_eq!(verify.roles[0].members, 1);
+        assert_eq!(verify.roles[1].members, 1);
+
+        // Remove user_a entirely (guild unlink) and re-run — no stale
+        // decrement bookkeeping needed, and it can never go negative/underflow.
+        verify.user_links.remove(&user_a);
+        verify.recompute_role_members();
+        assert_eq!(verify.roles[0].members, 0);
+        assert_eq!(verify.roles[1].members, 1);
+    }
 }
 

--- a/api/src/users/link_guilds.rs
+++ b/api/src/users/link_guilds.rs
@@ -66,7 +66,7 @@ async fn put_link_guilds_id(
 
     guild.verify.user_links.insert(user_id, user.links.clone());
 
-    for verify_role in &mut guild.verify.roles {
+    for verify_role in &guild.verify.roles {
         if link_arr_match(&user.links, &verify_role.pattern) {
             add_guild_member_role(
                 guild_id,
@@ -75,9 +75,12 @@ async fn put_link_guilds_id(
                 &app_state.discord_bot,
             )
             .await?;
-            verify_role.members += 1;
         }
     }
+    // Derive `members` from `user_links` (now updated above) rather than
+    // hand-incrementing it, so this stays consistent with every other
+    // mutation site (link add/remove, role add/remove, recon).
+    guild.verify.recompute_role_members();
 
     guild.save(&app_state.pg_pool).await;
     
@@ -106,16 +109,16 @@ async fn delete_link_guilds_id(
 
     let mut guild = Guild::from_db(guild_id, &app_state.pg_pool).await.unwrap();
 
-    for role in &mut guild.verify.roles {
+    for role in &guild.verify.roles {
         if link_arr_match(&user.links, &role.pattern) {
             remove_guild_member_role(guild_id, user_id, role.role_id, &app_state.discord_bot)
                 .await?;
-            if role.members > 0 {
-                role.members -= 1;
-            }
         }
     }
     guild.verify.user_links.remove(&user_id);
+    // Recompute instead of the old `if role.members > 0 { role.members -= 1 }`
+    // guard, which was only needed because the counter could otherwise drift.
+    guild.verify.recompute_role_members();
 
     user.save(&app_state.pg_pool).await;
     guild.save(&app_state.pg_pool).await;

--- a/api/src/users/links.rs
+++ b/api/src/users/links.rs
@@ -111,7 +111,7 @@ async fn post_link(
         let mut guild = Guild::from_db(link_guild.guild_id, &app_state.pg_pool)
             .await
             .unwrap();
-        for role in &mut guild.verify.roles {
+        for role in &guild.verify.roles {
             if link_match(&new_link, &role.pattern) {
                 add_guild_member_role(
                     guild.guild_id,
@@ -120,7 +120,6 @@ async fn post_link(
                     &app_state.discord_bot,
                 )
                 .await?;
-                role.members += 1;
             }
         }
         guild
@@ -129,6 +128,11 @@ async fn post_link(
             .get_mut(&user_id)
             .unwrap()
             .push(new_link.clone());
+        // Recompute from `user_links` instead of incrementing `role.members`
+        // by hand: a remove-then-re-add of the same address (see the
+        // `retain` above) would otherwise inflate the count every time the
+        // user re-links an address they already had.
+        guild.verify.recompute_role_members();
         guild.save(&app_state.pg_pool).await;
     }
     user_model.links.push(new_link.clone());
@@ -206,7 +210,7 @@ async fn delete_link(
             .verify
             .user_links
             .insert(user_id, active_only_links.clone());
-        for role in &mut guild.verify.roles {
+        for role in &guild.verify.roles {
             if !link_arr_match(
                 guild.verify.user_links.get(&user_id).unwrap(),
                 &role.pattern,
@@ -219,11 +223,12 @@ async fn delete_link(
                     &app_state.discord_bot,
                 )
                 .await?;
-                if role.members > 0 {
-                    role.members -= 1;
-                }
             }
         }
+        // `user_links` was already updated above; derive `members` from it
+        // instead of the old `if role.members > 0 { role.members -= 1 }`
+        // guard, which only existed because the counter was untrustworthy.
+        guild.verify.recompute_role_members();
         guild.save(&app_state.pg_pool).await;
     }
     existing_link.active = false;


### PR DESCRIPTION
## Problem

`VerifyRole::members` was maintained by hand across several call sites in the `api` crate, and the invariants didn't hold (koalabotuk/kb2#28):

1. **`post_link` (`api/src/users/links.rs`) double-counted on relink.** It did `user_model.links.retain(...)` to drop any existing link with the same address, then pushed the new one and did `role.members += 1` for every matching role — even if the user was already counted for that role via the link that was just removed. Re-adding an email you already had inflated the counter every time.
2. **`add`/`remove` role handlers didn't de-dup by member.** Multiple call sites incremented/decremented `role.members` by one per *link* rather than per *member*, and multiple active links matching the same pattern could push the count above the true number of members.
3. **`post_recon` (`api/src/guilds/verify/controllers.rs`) used a different counting method than `put_roles_id`**, so a "correct" recon and the live add/remove/link paths could disagree again immediately afterward.
4. Several sites carried `if role.members > 0 { role.members -= 1 }` guards (`links.rs:222`, `link_guilds.rs:113`) — a symptom of the counter already being untrustworthy.

## Fix

Implements the issue's second suggested resolution: centralize all mutations in one helper that recomputes the count from `guild.verify.user_links`, so every code path (`post_link`, `delete_link`, `put_link_guilds_id`, `delete_link_guilds_id`, `put_roles_id`, `post_recon`) agrees.

Added `Verify::recompute_role_members()` in `api/src/guilds/verify/models.rs`:

```rust
pub fn recompute_role_members(&mut self) {
    let user_links = &self.user_links;
    for role in &mut self.roles {
        role.members = user_links
            .values()
            .filter(|links| link_arr_match(links, &role.pattern))
            .count() as u32;
    }
}
```

This counts once per `user_links` entry (i.e. once per member) regardless of how many of that member's active links match the pattern, so it can't overcount. Every handler now updates `user_links` first (as they already did) and then calls `guild.verify.recompute_role_members()` instead of hand-incrementing/decrementing `role.members`. The `if role.members > 0 { role.members -= 1 }` guards are removed since they're no longer needed — the count is always derived fresh.

Files touched:
- `api/src/guilds/verify/models.rs` — new `Verify::recompute_role_members()` + tests
- `api/src/guilds/verify/controllers.rs` — `put_roles_id`, `post_recon`
- `api/src/users/links.rs` — `post_link`, `delete_link`
- `api/src/users/link_guilds.rs` — `put_link_guilds_id`, `delete_link_guilds_id`

## Tests (TDD)

Added 4 unit tests in `api/src/guilds/verify/models.rs` (`#[cfg(test)] mod tests`, following the existing convention in `consumer/src/audit/consumer.rs`) that exercise `Verify::recompute_role_members()` directly against an in-memory `Verify`/`user_links` map — no DB or Discord API needed:

- `recompute_role_members_does_not_double_count_on_relink` — reproduces the exact `post_link` bug: remove-then-re-add of the same address must keep the count at 1, not 2.
- `recompute_role_members_dedupes_multiple_matching_links_for_one_user` — a member with several active links matching the same role pattern still counts once.
- `recompute_role_members_ignores_inactive_links_and_tracks_removal` — deactivated links don't count, and removal drops the count to 0 with no underflow risk.
- `recompute_role_members_keeps_multiple_roles_consistent` — two roles derive independent correct counts from a shared `user_links` map, and removing a user updates both without stale decrement bookkeeping.

Ran with:
```
cargo test -p api recompute_role_members
```
All 4 pass; `cargo check -p api` is clean.

**Not covered:** full integration tests through the axum handlers (`post_link`, `post_recon`, etc.) — these need a live Postgres DB and Discord bot token/API, which aren't available in this environment. The handler-level changes are mechanical (swap manual +=/-= for a call to `recompute_role_members()` after `user_links` is updated) and were verified by reading through each call site plus `cargo check -p api`.

Closes #28.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EZWfJfvGVV3o7JxzUHGBMG)_