### PR TITLE
fix(api): constant-time secret comparisons and handle missing auth header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sqlx",
+ "subtle",
  "tokio",
  "tower-http",
  "twilight-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ regex = "1.11.2"
 cached = { version = "0.56.0", features = ["async"] }
 hmac = "0.12.1"
 sha2 = "0.10.9"
+subtle = "2.6.1"
 jwt = "0.16.0"
 sqlx = { version = "0.8", features = [ "runtime-tokio", "tls-rustls" , "postgres", "uuid", "bigdecimal"] }
 aws-sdk-dsql = "1.1"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -26,6 +26,7 @@ regex = { workspace = true }
 cached = { workspace = true, features = ["async"] }
 hmac = { workspace = true }
 sha2 = { workspace = true }
+subtle = { workspace = true }
 jwt = { workspace = true }
 sqlx = { workspace = true, features = [ "runtime-tokio", "tls-rustls" , "postgres", "uuid", "bigdecimal"] }
 bigdecimal = { workspace = true }

--- a/api/src/guilds/verify/controllers.rs
+++ b/api/src/guilds/verify/controllers.rs
@@ -3,7 +3,7 @@ use crate::discord::{add_guild_member_role, remove_guild_member_role};
 use crate::guilds::models::Guild;
 use crate::guilds::verify::models::{Verify, VerifyRole};
 use crate::users::utils::link_arr_match;
-use crate::utils::is_client_admin_guild;
+use crate::utils::{is_client_admin_guild, secure_compare};
 use axum::extract::{Path, State};
 use axum::routing::{post, put};
 use axum::{Extension, Json};
@@ -128,7 +128,11 @@ async fn post_recon(
     Extension(discord_user): Extension<Arc<twilight_http::Client>>,
     State(app_state): State<AppState>,
 ) -> Result<StatusCode, StatusCode> {
-    if discord_user.token() != app_state.discord_bot.token() {
+    let tokens_match = match (discord_user.token(), app_state.discord_bot.token()) {
+        (Some(a), Some(b)) => secure_compare(a, b),
+        _ => false,
+    };
+    if !tokens_match {
         return Err(StatusCode::FORBIDDEN);
     }
 

--- a/api/src/interactions/mod.rs
+++ b/api/src/interactions/mod.rs
@@ -1,5 +1,6 @@
 use crate::AppState;
 use crate::discord::ise;
+use crate::utils::secure_compare;
 use axum::extract::{Request, State};
 use axum::middleware::Next;
 use axum::response::Response;
@@ -48,16 +49,12 @@ pub async fn pubkey_middleware(request: Request, next: Next) -> Result<Response,
     let body = body.collect().await.map_err(ise)?.to_bytes();
     let headers = parts.headers.clone();
     let new_request = Request::from_parts(parts, axum::body::Body::from(body.clone()));
-    if headers.get(AUTHORIZATION)
-        == Some(
-            &format!(
-                "Bot {}",
-                std::env::var("DISCORD_BOT_TOKEN").expect("DISCORD_BOT_TOKEN must be set")
-            )
-            .as_str()
-            .parse()
-            .unwrap(),
-        )
+    let expected_bot_auth = format!(
+        "Bot {}",
+        std::env::var("DISCORD_BOT_TOKEN").expect("DISCORD_BOT_TOKEN must be set")
+    );
+    if let Some(auth_header) = headers.get(AUTHORIZATION).and_then(|v| v.to_str().ok())
+        && secure_compare(auth_header, &expected_bot_auth)
     {
         return Ok(next.run(new_request).await);
     }
@@ -221,17 +218,24 @@ A: Koala requires approval from some IT administrators, you can use the `other` 
     })))
 }
 
+/// Pull the `Authorization` header value out of the request, returning
+/// `401 Unauthorized` (rather than panicking) when the header is absent
+/// entirely, and `400 Bad Request` when present but not valid UTF-8.
+fn extract_auth_token(header_map: &HeaderMap) -> Result<&str, StatusCode> {
+    header_map
+        .get("Authorization")
+        .ok_or(StatusCode::UNAUTHORIZED)?
+        .to_str()
+        .map_err(|_| StatusCode::BAD_REQUEST)
+}
+
 async fn register_commands(
     header_map: HeaderMap,
     State(app_state): State<AppState>,
 ) -> Result<Json<Value>, StatusCode> {
-    let auth_token = header_map
-        .get("Authorization")
-        .unwrap()
-        .to_str()
-        .map_err(|_| StatusCode::BAD_REQUEST)?;
+    let auth_token = extract_auth_token(&header_map)?;
 
-    if auth_token != app_state.discord_bot.token().unwrap() {
+    if !secure_compare(auth_token, app_state.discord_bot.token().unwrap()) {
         return Err(StatusCode::UNAUTHORIZED);
     }
 
@@ -297,4 +301,42 @@ async fn register_commands(
         .await
         .map_err(ise)?;
     Ok(Json(json!(resp)))
+}
+
+#[cfg(test)]
+mod register_commands_tests {
+    use super::extract_auth_token;
+    use http::{HeaderMap, HeaderValue, StatusCode};
+
+    #[test]
+    fn missing_authorization_header_returns_unauthorized_instead_of_panicking() {
+        let header_map = HeaderMap::new();
+
+        let result = extract_auth_token(&header_map);
+
+        assert_eq!(result, Err(StatusCode::UNAUTHORIZED));
+    }
+
+    #[test]
+    fn present_authorization_header_is_extracted() {
+        let mut header_map = HeaderMap::new();
+        header_map.insert("Authorization", HeaderValue::from_static("Bot some-token"));
+
+        let result = extract_auth_token(&header_map);
+
+        assert_eq!(result, Ok("Bot some-token"));
+    }
+
+    #[test]
+    fn non_utf8_authorization_header_returns_bad_request() {
+        let mut header_map = HeaderMap::new();
+        header_map.insert(
+            "Authorization",
+            HeaderValue::from_bytes(&[0xff, 0xfe]).unwrap(),
+        );
+
+        let result = extract_auth_token(&header_map);
+
+        assert_eq!(result, Err(StatusCode::BAD_REQUEST));
+    }
 }

--- a/api/src/middleware.rs
+++ b/api/src/middleware.rs
@@ -1,4 +1,5 @@
 use crate::discord::{get_current_user, ise};
+use crate::utils::secure_compare;
 use axum::extract::Request;
 use axum::http::{HeaderMap, StatusCode};
 use axum::middleware::Next;
@@ -32,9 +33,9 @@ pub async fn auth_middleware(
             Ok(next.run(request).await)
         }
         "Bot" => {
-            if credentials
-                != std::env::var("DISCORD_BOT_TOKEN").expect("DISCORD_BOT_TOKEN must be set")
-            {
+            let expected_token =
+                std::env::var("DISCORD_BOT_TOKEN").expect("DISCORD_BOT_TOKEN must be set");
+            if !secure_compare(credentials, &expected_token) {
                 return Err(StatusCode::UNAUTHORIZED);
             }
             let client = Client::new(format!("Bot {credentials}"));

--- a/api/src/utils.rs
+++ b/api/src/utils.rs
@@ -1,10 +1,20 @@
 use crate::discord::{get_current_user_guilds, get_guild, get_guild_member};
 use http::StatusCode;
+use subtle::ConstantTimeEq;
 use twilight_http::Client;
 use twilight_model::guild::Permissions;
 use twilight_model::id::Id;
 use twilight_model::id::marker::GuildMarker;
 use twilight_model::user::{CurrentUser, CurrentUserGuild};
+
+/// Compare two secrets (e.g. bot tokens) in constant time.
+///
+/// Using `==` on strings/bytes short-circuits on the first mismatched byte,
+/// which leaks timing information that can be used to recover a secret
+/// byte-by-byte. This compares the full contents in constant time instead.
+pub fn secure_compare(a: &str, b: &str) -> bool {
+    a.as_bytes().ct_eq(b.as_bytes()).into()
+}
 
 pub async fn member_guilds(
     discord_user: &Client,
@@ -65,4 +75,34 @@ pub async fn admin_guilds(
 
 pub fn is_admin(guild: &CurrentUserGuild) -> bool {
     guild.owner || guild.permissions & Permissions::ADMINISTRATOR == Permissions::ADMINISTRATOR
+}
+
+#[cfg(test)]
+mod secure_compare_tests {
+    use super::secure_compare;
+
+    #[test]
+    fn matching_secrets_are_accepted() {
+        assert!(secure_compare("super-secret-token", "super-secret-token"));
+    }
+
+    #[test]
+    fn non_matching_secrets_are_rejected() {
+        assert!(!secure_compare("super-secret-token", "not-the-token"));
+    }
+
+    #[test]
+    fn secrets_of_different_length_are_rejected() {
+        assert!(!secure_compare("short", "a-much-longer-secret"));
+    }
+
+    #[test]
+    fn empty_strings_are_equal() {
+        assert!(secure_compare("", ""));
+    }
+
+    #[test]
+    fn case_sensitive_comparison() {
+        assert!(!secure_compare("Token", "token"));
+    }
 }


### PR DESCRIPTION
## Bugs fixed

**1. Non-constant-time secret comparisons (timing side channel)**

The Discord bot token is used as a super-user credential in four places, each previously compared with `==`, which short-circuits on the first mismatched byte and leaks timing information an attacker could use to recover the token byte-by-byte:

- `api/src/middleware.rs` — `auth_middleware`'s `Bot` scheme branch
- `api/src/interactions/mod.rs` — `pubkey_middleware`'s signature-check bypass
- `api/src/interactions/mod.rs` — `register_commands`
- `api/src/guilds/verify/controllers.rs` — `post_recon`

Added a `secure_compare` helper in `api/src/utils.rs`, backed by `subtle::ConstantTimeEq` (the `subtle` crate was already a transitive dependency via `ed25519-dalek`/`hmac`, so it's now added as a direct workspace dependency), and used it at all four call sites.

**2. `register_commands` panics on a missing `Authorization` header**

`POST /interactions/register` is mounted outside `auth_middleware`, so an anonymous request with no `Authorization` header at all hit `.unwrap()` on `header_map.get("Authorization")` and panicked (500), instead of failing cleanly.

Extracted the header lookup into `extract_auth_token`, which now returns `401 Unauthorized` when the header is absent and `400 Bad Request` when present but not valid UTF-8, instead of panicking.

## Tests added

`api/src/utils.rs` (`secure_compare_tests`):
- matching secrets are accepted
- non-matching secrets are rejected
- secrets of different length are rejected
- empty strings are equal
- comparison is case-sensitive

`api/src/interactions/mod.rs` (`register_commands_tests`):
- missing `Authorization` header returns `401 Unauthorized` instead of panicking (the core regression test for this bug)
- present `Authorization` header is extracted correctly
- non-UTF8 `Authorization` header returns `400 Bad Request`

## Verification

- `cargo test -p api` — 8/8 tests pass
- `cargo check -p api` and `cargo check --workspace` — clean
- `cargo clippy -p api --all-targets` — no new warnings introduced

Closes #22

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZWfJfvGVV3o7JxzUHGBMG)_