### PR TITLE
fix(api): repair scheduled vote-close pipeline (EventBridge name/at()/role, callback auth, panic)

### DIFF
--- a/api/src/guilds/votes/controllers.rs
+++ b/api/src/guilds/votes/controllers.rs
@@ -15,6 +15,7 @@ use lambda_http::aws_lambda_events::apigw::ApiGatewayProxyRequest;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 use tower_http::cors::CorsLayer;
 use twilight_model::channel::message::{Component, EmojiReactionType};
 use twilight_model::id::Id;
@@ -102,14 +103,20 @@ async fn post_votes(
     guild.vote.votes.push(new_vote.clone());
     guild.save(&app_state.pg_pool).await;
 
-    if vote_req.close_at.is_some() {
+    if let Some(close_at) = vote_req.close_at {
         let mut headers = HeaderMap::new();
         headers.insert(CONTENT_TYPE, "application/json".parse().unwrap());
         headers.insert(
             AUTHORIZATION,
-            format!("Discord {}", app_state.discord_bot.token().unwrap())
-                .parse()
-                .unwrap(),
+            // The scheduled callback must authenticate as the bot: the `Discord`
+            // auth scheme builds a `Bearer` client and explicitly rejects bots,
+            // so it can never succeed here.
+            format!(
+                "Bot {}",
+                std::env::var("DISCORD_BOT_TOKEN").expect("DISCORD_BOT_TOKEN must be set")
+            )
+            .parse()
+            .unwrap(),
         );
 
         let payload = ApiGatewayProxyRequest {
@@ -130,9 +137,16 @@ async fn post_votes(
             ..Default::default()
         };
 
+        // `context.identity` is only populated for Cognito-identity invocations
+        // (None behind API Gateway/function URLs) and, even when present, is not
+        // an IAM role ARN. The EventBridge Scheduler execution role is instead
+        // supplied via configuration.
+        let scheduler_role_arn =
+            std::env::var("SCHEDULER_ROLE_ARN").expect("SCHEDULER_ROLE_ARN must be set");
+
         let target = Target::builder()
             .arn(context.invoked_function_arn)
-            .role_arn(context.identity.unwrap().identity_id)
+            .role_arn(scheduler_role_arn)
             .input(json!({"payload": payload, "context": Context::default()}).to_string())
             .build()
             .map_err(ise)?;
@@ -140,8 +154,8 @@ async fn post_votes(
         let _result = app_state
             .scheduler
             .create_schedule()
-            .name(format!("KB2 Vote Close {}", message.id))
-            .schedule_expression(format!("at({})", vote_req.close_at.unwrap()))
+            .name(vote_close_schedule_name(message.id))
+            .schedule_expression(vote_close_schedule_expression(close_at))
             .target(target)
             .flexible_time_window(
                 FlexibleTimeWindow::builder()
@@ -155,6 +169,18 @@ async fn post_votes(
     }
 
     Ok(Json(json!(new_vote)))
+}
+
+/// EventBridge Scheduler schedule names must match `[0-9a-zA-Z\-_.]{1,64}`.
+/// Spaces (as in the original `"KB2 Vote Close {id}"`) are invalid.
+fn vote_close_schedule_name(message_id: Id<MessageMarker>) -> String {
+    format!("kb2-vote-close-{}", message_id)
+}
+
+/// EventBridge Scheduler's `at()` expression requires `yyyy-mm-ddThh:mm:ss`.
+/// `DateTime`'s `Display` impl (e.g. `2026-07-02 12:00:00 UTC`) is not valid.
+fn vote_close_schedule_expression(close_at: DateTime<Utc>) -> String {
+    format!("at({})", close_at.format("%Y-%m-%dT%H:%M:%S"))
 }
 
 async fn get_votes_id(
@@ -176,15 +202,13 @@ async fn get_votes_id(
     Ok(Json(json!(vote)))
 }
 
-async fn post_votes_id_close(
-    Path((guild_id, message_id)): Path<(Id<GuildMarker>, Id<MessageMarker>)>,
-    Extension(current_user): Extension<CurrentUser>,
-    State(app_state): State<AppState>,
-) -> Result<Json<Value>, StatusCode> {
-    if !utils::is_client_admin_guild(guild_id, &current_user, &app_state.discord_bot).await? {
-        return Err(StatusCode::FORBIDDEN);
-    }
-
+/// Closes a vote and updates the Discord message. Shared by both the
+/// admin-initiated close route and the EventBridge Scheduler callback.
+async fn close_vote(
+    guild_id: Id<GuildMarker>,
+    message_id: Id<MessageMarker>,
+    app_state: &AppState,
+) -> Result<VoteVote, StatusCode> {
     let mut guild = Guild::from_db(guild_id, &app_state.pg_pool).await.unwrap();
     let vote: &mut VoteVote = match guild
         .vote
@@ -230,5 +254,77 @@ async fn post_votes_id_close(
     )
     .await?;
 
+    Ok(vote.clone())
+}
+
+async fn post_votes_id_close(
+    Path((guild_id, message_id)): Path<(Id<GuildMarker>, Id<MessageMarker>)>,
+    Extension(discord_client): Extension<Arc<twilight_http::Client>>,
+    current_user: Option<Extension<CurrentUser>>,
+    State(app_state): State<AppState>,
+) -> Result<Json<Value>, StatusCode> {
+    // This route is hit two ways: by an admin closing a vote early (`Discord`
+    // auth scheme, with a `CurrentUser` extension inserted by auth_middleware),
+    // and by the EventBridge Scheduler callback closing it automatically
+    // (`Bot` auth scheme, which never inserts a `CurrentUser`). Follow the
+    // `post_recon` pattern for the latter: compare the authenticated client's
+    // token to the bot's own token rather than requiring `Extension<CurrentUser>`.
+    let is_bot_callback = discord_client.token() == app_state.discord_bot.token();
+    if !is_bot_callback {
+        let Extension(current_user) = current_user.ok_or(StatusCode::UNAUTHORIZED)?;
+        if !utils::is_client_admin_guild(guild_id, &current_user, &app_state.discord_bot).await? {
+            return Err(StatusCode::FORBIDDEN);
+        }
+    }
+
+    let vote = close_vote(guild_id, message_id, &app_state).await?;
+
     Ok(Json(json!(vote)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    // EventBridge Scheduler schedule names must match `[0-9a-zA-Z\-_.]{1,64}`.
+    fn is_valid_schedule_name(name: &str) -> bool {
+        !name.is_empty()
+            && name.len() <= 64
+            && name
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+    }
+
+    #[test]
+    fn schedule_name_contains_no_spaces_and_uses_message_id() {
+        let message_id: Id<MessageMarker> = Id::new(1234567890123456789);
+        let name = vote_close_schedule_name(message_id);
+
+        assert_eq!(name, "kb2-vote-close-1234567890123456789");
+        assert!(
+            is_valid_schedule_name(&name),
+            "schedule name {name:?} does not match EventBridge Scheduler's allowed pattern"
+        );
+    }
+
+    #[test]
+    fn schedule_expression_uses_at_format_without_timezone_suffix() {
+        let close_at = Utc.with_ymd_and_hms(2026, 7, 2, 12, 0, 0).unwrap();
+
+        let expr = vote_close_schedule_expression(close_at);
+
+        // Must be `at(yyyy-mm-ddThh:mm:ss)`, not `DateTime`'s
+        // `Display` output (`2026-07-02 12:00:00 UTC`).
+        assert_eq!(expr, "at(2026-07-02T12:00:00)");
+    }
+
+    #[test]
+    fn schedule_expression_zero_pads_single_digit_components() {
+        let close_at = Utc.with_ymd_and_hms(2026, 1, 5, 3, 4, 5).unwrap();
+
+        let expr = vote_close_schedule_expression(close_at);
+
+        assert_eq!(expr, "at(2026-01-05T03:04:05)");
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the five independent defects in the `close_at` scheduling path described in #19 (`api/src/guilds/votes/controllers.rs`, `api/src/middleware.rs`).

1. **Panic / wrong role ARN** — `Target.role_arn` used `context.identity.unwrap().identity_id`, which is `None` behind API Gateway/function URLs (panics) and isn't an IAM role ARN even when present. Now read from a `SCHEDULER_ROLE_ARN` environment variable, as suggested in the issue.
2. **Invalid schedule name** — `"KB2 Vote Close {id}"` contains spaces, which EventBridge Scheduler rejects (`[0-9a-zA-Z\-_.]{1,64}` only). Now `"kb2-vote-close-{id}"`.
3. **Invalid `at()` expression** — used `DateTime`'s `Display` (`2026-07-02 12:00:00 UTC`); `at()` requires `yyyy-mm-ddThh:mm:ss`. Now formatted with `close_at.format("%Y-%m-%dT%H:%M:%S")`.
4. **Callback auth could never succeed** — the scheduled payload sent `Authorization: Discord {bot_token}`. The `Discord` scheme builds a `Bearer` client and explicitly rejects bots. Now sends `Authorization: Bot {token}`, matching the `Bot` scheme `auth_middleware` already supports.
5. **500 on the scheduler's callback** — `post_votes_id_close` required `Extension<CurrentUser>`, which the `Bot` auth branch never inserts. The handler now accepts `Extension<Arc<twilight_http::Client>>` plus an *optional* `CurrentUser`: if the authenticated client's token matches the bot's own token (the scheduler calling back, `Bot` scheme — mirrors the `post_recon` pattern), the admin check is skipped; otherwise it falls back to the existing `is_client_admin_guild` check for a human admin (`Discord` scheme). The actual close logic was split out into an internal `close_vote(guild_id, message_id, &app_state)` shared by both callers.

## Tests added (TDD)

Added `#[cfg(test)] mod tests` in `api/src/guilds/votes/controllers.rs` covering the two bugs that are pure, unit-testable logic:
- `schedule_name_contains_no_spaces_and_uses_message_id` — asserts `vote_close_schedule_name` produces `kb2-vote-close-{id}` and validates it against EventBridge Scheduler's allowed name pattern.
- `schedule_expression_uses_at_format_without_timezone_suffix` / `schedule_expression_zero_pads_single_digit_components` — assert `vote_close_schedule_expression` produces `at(yyyy-mm-ddThh:mm:ss)`, not `DateTime`'s default `Display` output.

Ran `cargo test -p api` (3/3 new tests pass) and `cargo check -p api` (clean, no warnings).

The role-ARN/env-var wiring, the callback-auth scheme switch, and the auth-fallback logic in `post_votes_id_close` are not independently unit-testable without a live AWS/Discord/DB environment (they depend on `AppState`, `axum` extractors, and outbound HTTP), so they're covered by code review + the existing manual/e2e path rather than new unit tests.

## Not fixed here (flagged, not guessed at)

The fix makes the code correctly *read* `SCHEDULER_ROLE_ARN`, but there is currently **no infra provisioning it**:
- `infra/modules/compute/lambda/main.tf` has no IAM role for EventBridge Scheduler to assume (needs a trust policy allowing `scheduler.amazonaws.com` to assume it, plus `lambda:InvokeFunction` on the API Lambda), and no `SCHEDULER_ROLE_ARN` environment variable wired into the Lambda's `environment` block.
- The API Lambda's own execution role (`aws_iam_role.lambda_execute_role`) has no `scheduler:CreateSchedule` or `iam:PassRole` (scoped to the new role) permission, which `create_schedule().send()` requires.

I did not add these because they involve security-sensitive trust-policy/least-privilege decisions and account-specific verification (existing scheduler groups, naming/tagging conventions) that I can't confirm from code alone — grep confirms nothing "scheduler"-related exists in `infra/` today, so this is new infra, not a fix to something broken. Once `SCHEDULER_ROLE_ARN` is provisioned and set, the code path here will work correctly; until then the `.expect("SCHEDULER_ROLE_ARN must be set")` will panic clearly (with a 500) rather than silently misbehaving, which is strictly better than the previous always-panicking `context.identity.unwrap()`.

Addresses #19


---
_Generated by [Claude Code](https://claude.ai/code/session_01EZWfJfvGVV3o7JxzUHGBMG)_