### PR TITLE
fix: install zig in api-deploy CI (regression from #66)

### DIFF
--- a/.github/workflows/api-deploy.yml
+++ b/.github/workflows/api-deploy.yml
@@ -31,6 +31,8 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1
         with:
           repo: cargo-lambda/cargo-lambda
+      - name: Install Zig
+        run: npm install -g @ziglang/cli
       - name: Install dependencies
         run: cargo install sqlx-cli
       - name: Build


### PR DESCRIPTION
## Problem
CI has been failing on every push to `main` since PR #66 merged:

```
Error:   × Zig is not installed in your system, please install it and run Cargo Lambda again
```

PR #66 (closing #50) removed the Python 3.11 setup step from `api-deploy.yml` because the crate is all-Rust and Python wasn't otherwise needed. That was correct, but that step was *also* implicitly installing Zig via `pip3 install ziglang` — `cargo-lambda build` needs Zig on PATH for its cross-compilation toolchain. Removing Python silently dropped Zig too.

## Fix
Add an explicit `Install Zig` step using `npm install -g @ziglang/cli` (Node is already present on the runner), rather than reintroducing the Python toolchain just for this one dependency.

Verified against the failed run logs (run 28607764241) — the error occurs at exactly the `cargo lambda build` step this fix targets.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZWfJfvGVV3o7JxzUHGBMG)_