### PR TITLE
fix(api): validate verify role regex patterns; never panic on stored ones

### DIFF
--- a/api/src/guilds/verify/controllers.rs
+++ b/api/src/guilds/verify/controllers.rs
@@ -8,6 +8,7 @@ use axum::extract::{Path, State};
 use axum::routing::{post, put};
 use axum::{Extension, Json};
 use http::StatusCode;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::sync::Arc;
@@ -31,6 +32,17 @@ struct PutRoleRequest {
     pub pattern: String,
 }
 
+/// Validates that a verify-role pattern compiles as a regex. Invalid
+/// patterns must never be persisted: once stored, every code path that
+/// matches links against the guild's roles would otherwise need to handle
+/// (or, before this fix, panic on) an uncompilable pattern.
+fn validate_verify_pattern(pattern: &str) -> Result<(), StatusCode> {
+    if Regex::new(pattern).is_err() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    Ok(())
+}
+
 async fn put_roles_id(
     Path((guild_id, role_id)): Path<(Id<GuildMarker>, Id<RoleMarker>)>,
     Extension(current_user): Extension<CurrentUser>,
@@ -40,6 +52,8 @@ async fn put_roles_id(
     if !is_client_admin_guild(guild_id, &current_user, &app_state.discord_bot).await? {
         return Err(StatusCode::FORBIDDEN);
     }
+
+    validate_verify_pattern(&put_role_request.pattern)?;
 
     let mut guild = Guild::from_db(guild_id, &app_state.pg_pool).await.unwrap();
 
@@ -171,4 +185,24 @@ async fn post_recon(
     guild.save(&app_state.pg_pool).await;
 
     Ok(StatusCode::NO_CONTENT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_pattern_is_rejected_at_creation_time() {
+        // `(` is not a valid regex — this must be rejected up front with a
+        // clean 400 instead of being persisted and panicking later.
+        assert_eq!(
+            validate_verify_pattern("("),
+            Err(StatusCode::BAD_REQUEST)
+        );
+    }
+
+    #[test]
+    fn valid_pattern_is_accepted() {
+        assert_eq!(validate_verify_pattern(r"^https://example\.com/.*$"), Ok(()));
+    }
 }

--- a/api/src/users/utils.rs
+++ b/api/src/users/utils.rs
@@ -1,14 +1,61 @@
 use crate::users::models::Link;
+use lambda_http::tracing::error;
 use regex::Regex;
 
+/// Never panics: a pattern that fails to compile (e.g. corrupted/legacy data
+/// that slipped past validation at write time) is treated as "matches
+/// nothing" rather than bringing down the whole guild's verify flow.
 pub fn link_arr_match(links: &[Link], pattern: &str) -> bool {
-    let regex = Regex::new(pattern).unwrap();
-    links
-        .iter()
-        .any(|l| l.active && regex.is_match(&l.link_address))
+    match Regex::new(pattern) {
+        Ok(regex) => links
+            .iter()
+            .any(|l| l.active && regex.is_match(&l.link_address)),
+        Err(e) => {
+            error!("Invalid verify pattern {pattern:?}: {e}");
+            false
+        }
+    }
 }
 
 pub fn link_match(link: &Link, pattern: &str) -> bool {
-    let regex = Regex::new(pattern).unwrap();
-    link.active && regex.is_match(&link.link_address)
+    match Regex::new(pattern) {
+        Ok(regex) => link.active && regex.is_match(&link.link_address),
+        Err(e) => {
+            error!("Invalid verify pattern {pattern:?}: {e}");
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn link(address: &str, active: bool) -> Link {
+        Link {
+            link_address: address.to_string(),
+            linked_at: 0,
+            active,
+        }
+    }
+
+    #[test]
+    fn link_match_returns_false_for_invalid_pattern_instead_of_panicking() {
+        let l = link("https://example.com/user", true);
+        // `(` is not a valid regex — this must not panic downstream matching.
+        assert!(!link_match(&l, "("));
+    }
+
+    #[test]
+    fn link_arr_match_returns_false_for_invalid_pattern_instead_of_panicking() {
+        let links = vec![link("https://example.com/user", true)];
+        // `(` is not a valid regex — this must not panic downstream matching.
+        assert!(!link_arr_match(&links, "("));
+    }
+
+    #[test]
+    fn link_match_still_matches_valid_pattern() {
+        let l = link("https://example.com/user", true);
+        assert!(link_match(&l, r"^https://example\.com/.*$"));
+    }
 }


### PR DESCRIPTION
## Bug

Verify role patterns were compiled with `Regex::new(pattern).unwrap()` in `link_arr_match`/`link_match` (`api/src/users/utils.rs`), and `PUT /guilds/{id}/verify/roles/{role_id}` (`api/src/guilds/verify/controllers.rs`) accepted any pattern verbatim with no validation.

A single invalid pattern such as `(`:
1. panicked `put_roles_id` itself the first time it was matched, and
2. was **persisted**, after which every code path touching the guild's roles panicked: user linking (`post_link`), link-guild enable/disable, `post_recon`, `delete_link` — bricking verify for that guild until the row was hand-edited.

## Fix

- **Validate at write time**: `put_roles_id` now rejects an invalid pattern with `400 Bad Request` before it can ever be persisted, via a new `validate_verify_pattern` helper.
- **Never panic on stored data (defense in depth)**: `link_arr_match`/`link_match` in `api/src/users/utils.rs` no longer `.unwrap()` the compiled regex. If a stored pattern somehow fails to compile, the error is logged and the pattern is treated as matching nothing, instead of panicking the request.

## Tests

Added `#[test]`s (TDD, all passing):
- `guilds::verify::controllers::tests::invalid_pattern_is_rejected_at_creation_time` — confirms an invalid pattern (`(`) is rejected with `400 Bad Request` via `validate_verify_pattern` instead of being accepted.
- `guilds::verify::controllers::tests::valid_pattern_is_accepted` — confirms a valid pattern still passes validation.
- `users::utils::tests::link_match_returns_false_for_invalid_pattern_instead_of_panicking` — confirms a stored/loaded invalid pattern doesn't panic `link_match`.
- `users::utils::tests::link_arr_match_returns_false_for_invalid_pattern_instead_of_panicking` — same for `link_arr_match`.
- `users::utils::tests::link_match_still_matches_valid_pattern` — regression guard that valid patterns still match as before.

Verified with `cargo test -p api` (all new tests pass) and `cargo check -p api` (clean, no errors/warnings).

Closes #18

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZWfJfvGVV3o7JxzUHGBMG)_