### PR TITLE
fix(api): return 401 instead of panicking on malformed Authorization header

### DIFF
--- a/api/src/middleware.rs
+++ b/api/src/middleware.rs
@@ -7,18 +7,27 @@ use http_body_util::BodyExt;
 use lambda_http::tracing::info;
 use twilight_http::Client;
 
+/// Parses the `Authorization` header into a `(scheme, credentials)` pair.
+///
+/// Returns `Err(StatusCode::UNAUTHORIZED)` (instead of panicking) if the
+/// header is missing, contains non-UTF8/non-visible-ASCII bytes, or does not
+/// contain the expected `<scheme> <credentials>` format.
+fn parse_auth_header(headers: &HeaderMap) -> Result<(&str, &str), StatusCode> {
+    let auth_header = headers
+        .get("Authorization")
+        .ok_or(StatusCode::UNAUTHORIZED)?
+        .to_str()
+        .map_err(|_| StatusCode::UNAUTHORIZED)?;
+    auth_header.split_once(' ').ok_or(StatusCode::UNAUTHORIZED)
+}
+
 pub async fn auth_middleware(
     headers: HeaderMap,
     mut request: Request,
     next: Next,
 ) -> Result<Response, StatusCode> {
     // do something with `request`...
-    if headers.get("Authorization").is_none() {
-        return Err(StatusCode::UNAUTHORIZED);
-    }
-
-    let auth_header = headers.get("Authorization").unwrap().to_str().unwrap();
-    let (scheme, credentials) = auth_header.split_once(' ').unwrap();
+    let (scheme, credentials) = parse_auth_header(&headers)?;
     match scheme {
         "Discord" => {
             let client = Client::new(format!("Bearer {credentials}"));
@@ -71,4 +80,69 @@ pub async fn mock_ctx_middleware(mut request: Request, next: Next) -> Result<Res
         .extensions_mut()
         .insert(lambda_http::Context::default());
     Ok(next.run(request).await)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    #[test]
+    fn parse_auth_header_missing_scheme_prefix_returns_unauthorized() {
+        // No space in the header value, so there is no `<scheme> <credentials>` split point.
+        let mut headers = HeaderMap::new();
+        headers.insert("Authorization", HeaderValue::from_static("x"));
+
+        let result = parse_auth_header(&headers);
+
+        assert_eq!(result.unwrap_err(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn parse_auth_header_non_utf8_returns_unauthorized() {
+        // Non-visible-ASCII / non-UTF8 bytes make `HeaderValue::to_str()` fail.
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "Authorization",
+            HeaderValue::from_bytes(&[0xC0, 0xAF]).expect("invalid header value bytes"),
+        );
+
+        let result = parse_auth_header(&headers);
+
+        assert_eq!(result.unwrap_err(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn parse_auth_header_missing_header_returns_unauthorized() {
+        let headers = HeaderMap::new();
+
+        let result = parse_auth_header(&headers);
+
+        assert_eq!(result.unwrap_err(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn parse_auth_header_well_formed_header_parses_successfully() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "Authorization",
+            HeaderValue::from_static("Discord some.jwt.token"),
+        );
+
+        let (scheme, credentials) = parse_auth_header(&headers).expect("should parse header");
+
+        assert_eq!(scheme, "Discord");
+        assert_eq!(credentials, "some.jwt.token");
+    }
+
+    #[test]
+    fn parse_auth_header_well_formed_bot_header_parses_successfully() {
+        let mut headers = HeaderMap::new();
+        headers.insert("Authorization", HeaderValue::from_static("Bot secret-token"));
+
+        let (scheme, credentials) = parse_auth_header(&headers).expect("should parse header");
+
+        assert_eq!(scheme, "Bot");
+        assert_eq!(credentials, "secret-token");
+    }
 }


### PR DESCRIPTION
## Bug
`auth_middleware` in `api/src/middleware.rs` used two unchecked `.unwrap()`s when reading the `Authorization` header:

```rust
let auth_header = headers.get("Authorization").unwrap().to_str().unwrap();
let (scheme, credentials) = auth_header.split_once(' ').unwrap();
```

Any client could trigger a panic (and a 500 instead of a 401) by sending:
- A header with no space (e.g. `Authorization: x`) — `split_once(' ')` panics.
- A header containing non-UTF8 bytes — `to_str()` panics.

## Fix
Extracted the parsing into a small helper, `parse_auth_header`, that returns `Result<(&str, &str), StatusCode>` instead of panicking:

```rust
fn parse_auth_header(headers: &HeaderMap) -> Result<(&str, &str), StatusCode> {
    let auth_header = headers
        .get("Authorization")
        .ok_or(StatusCode::UNAUTHORIZED)?
        .to_str()
        .map_err(|_| StatusCode::UNAUTHORIZED)?;
    auth_header.split_once(' ').ok_or(StatusCode::UNAUTHORIZED)
}
```

`auth_middleware` now calls this helper and propagates the `StatusCode::UNAUTHORIZED` via `?`. The redundant `headers.get("Authorization").is_none()` pre-check was removed since it's now handled by the helper.

I checked for issue #22's constant-time compare helper in `api/src/utils.rs` in case this should reuse it, but that fix isn't present in this codebase yet, so this PR stays scoped to the panic fix described in #17 and doesn't depend on it.

## Tests
Added unit tests in `api/src/middleware.rs` (`mod tests`) covering `parse_auth_header`:
- `parse_auth_header_missing_header_returns_unauthorized` — no `Authorization` header at all
- `parse_auth_header_missing_scheme_prefix_returns_unauthorized` — header with no space (e.g. `x`)
- `parse_auth_header_non_utf8_returns_unauthorized` — header value with invalid UTF-8 bytes
- `parse_auth_header_well_formed_header_parses_successfully` — well-formed `Discord <token>` header still parses correctly
- `parse_auth_header_well_formed_bot_header_parses_successfully` — well-formed `Bot <token>` header still parses correctly

Verified with:
```
cargo test -p api parse_auth_header   # 5 passed; 0 failed
cargo check -p api                    # clean
```

Closes #17

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZWfJfvGVV3o7JxzUHGBMG)_