### PR TITLE
fix(api): stop logging Authorization tokens and bodies in log_middleware

### DIFF
--- a/api/src/middleware.rs
+++ b/api/src/middleware.rs
@@ -1,11 +1,42 @@
-use crate::discord::{get_current_user, ise};
+use crate::discord::get_current_user;
 use axum::extract::Request;
 use axum::http::{HeaderMap, StatusCode};
 use axum::middleware::Next;
 use axum::response::Response;
-use http_body_util::BodyExt;
 use lambda_http::tracing::info;
 use twilight_http::Client;
+
+/// Value substituted for sensitive header values when logging.
+const REDACTED_PLACEHOLDER: &str = "***REDACTED***";
+
+/// Headers whose values must never be written to logs verbatim.
+///
+/// Comparison is case-insensitive (matching `http::HeaderName` semantics).
+const SENSITIVE_HEADERS: &[&str] = &["authorization", "cookie", "set-cookie"];
+
+/// Build a loggable representation of a header map with sensitive values
+/// (e.g. `Authorization` tokens, cookies) redacted.
+///
+/// This exists so request/response headers can still be logged for
+/// debugging purposes without leaking credentials (Discord OAuth access
+/// tokens, the bot token, session cookies, etc.) into CloudWatch.
+fn redact_headers(headers: &HeaderMap) -> Vec<(String, String)> {
+    headers
+        .iter()
+        .map(|(name, value)| {
+            let name = name.as_str().to_string();
+            if SENSITIVE_HEADERS.contains(&name.to_lowercase().as_str()) {
+                (name, REDACTED_PLACEHOLDER.to_string())
+            } else {
+                let value = value
+                    .to_str()
+                    .map(|v| v.to_string())
+                    .unwrap_or_else(|_| "<invalid utf-8>".to_string());
+                (name, value)
+            }
+        })
+        .collect()
+}
 
 pub async fn auth_middleware(
     headers: HeaderMap,
@@ -47,23 +78,31 @@ pub async fn auth_middleware(
 }
 
 pub async fn log_middleware(request: Request, next: Next) -> Result<Response, StatusCode> {
-    let (parts, body) = request.into_parts();
-    let body = body.collect().await.map_err(ise)?.to_bytes();
+    // Only capture method/URI/headers metadata - request and response bodies
+    // are never logged, as they may contain secrets (OIDC tokens) or PII
+    // (email addresses). Sensitive headers such as `Authorization` are
+    // redacted before logging.
+    let method = request.method().clone();
+    let uri = request.uri().clone();
+    let request_headers = redact_headers(request.headers());
 
-    info!("Received request: {:?} {:?}", parts, body);
+    info!(
+        "Received request: {} {} headers={:?}",
+        method, uri, request_headers
+    );
 
-    // Call the next middleware or handler
-    let response = next
-        .run(Request::from_parts(parts, axum::body::Body::from(body)))
-        .await;
+    let response = next.run(request).await;
 
-    let (parts, body) = response.into_parts();
-    let body = body.collect().await.map_err(ise)?.to_bytes();
+    let response_headers = redact_headers(response.headers());
+    info!(
+        "Response: {} {} -> {} headers={:?}",
+        method,
+        uri,
+        response.status(),
+        response_headers
+    );
 
-    // Log the response
-    info!("Response: {:?} {:?}", parts, body);
-
-    Ok(Response::from_parts(parts, axum::body::Body::from(body)))
+    Ok(response)
 }
 
 pub async fn mock_ctx_middleware(mut request: Request, next: Next) -> Result<Response, StatusCode> {
@@ -71,4 +110,105 @@ pub async fn mock_ctx_middleware(mut request: Request, next: Next) -> Result<Res
         .extensions_mut()
         .insert(lambda_http::Context::default());
     Ok(next.run(request).await)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    fn header_value(name: &str, redacted: &[(String, String)]) -> Option<String> {
+        redacted
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case(name))
+            .map(|(_, v)| v.clone())
+    }
+
+    #[test]
+    fn redact_headers_hides_authorization_value() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "Authorization",
+            HeaderValue::from_static("Discord super-secret-oauth-token"),
+        );
+        headers.insert("Content-Type", HeaderValue::from_static("application/json"));
+
+        let redacted = redact_headers(&headers);
+        let rendered = format!("{:?}", redacted);
+
+        // The raw secret must never appear anywhere in the loggable output.
+        assert!(!rendered.contains("super-secret-oauth-token"));
+        assert_eq!(
+            header_value("Authorization", &redacted).as_deref(),
+            Some(REDACTED_PLACEHOLDER)
+        );
+        // Non-sensitive headers should pass through unchanged.
+        assert_eq!(
+            header_value("Content-Type", &redacted).as_deref(),
+            Some("application/json")
+        );
+    }
+
+    #[test]
+    fn redact_headers_is_case_insensitive() {
+        let mut headers = HeaderMap::new();
+        // HeaderName normalizes case, but exercise via the lowercase form
+        // that http::HeaderName always reports from `.as_str()`.
+        headers.insert("authorization", HeaderValue::from_static("Bot abc123"));
+
+        let redacted = redact_headers(&headers);
+        let rendered = format!("{:?}", redacted);
+
+        assert!(!rendered.contains("abc123"));
+        assert_eq!(
+            header_value("authorization", &redacted).as_deref(),
+            Some(REDACTED_PLACEHOLDER)
+        );
+    }
+
+    #[test]
+    fn redact_headers_hides_cookies() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "Cookie",
+            HeaderValue::from_static("session=top-secret-session-id"),
+        );
+        headers.insert(
+            "Set-Cookie",
+            HeaderValue::from_static("session=another-secret; HttpOnly"),
+        );
+
+        let redacted = redact_headers(&headers);
+        let rendered = format!("{:?}", redacted);
+
+        assert!(!rendered.contains("top-secret-session-id"));
+        assert!(!rendered.contains("another-secret"));
+        assert_eq!(
+            header_value("Cookie", &redacted).as_deref(),
+            Some(REDACTED_PLACEHOLDER)
+        );
+        assert_eq!(
+            header_value("Set-Cookie", &redacted).as_deref(),
+            Some(REDACTED_PLACEHOLDER)
+        );
+    }
+
+    #[test]
+    fn redact_headers_preserves_non_sensitive_headers_and_count() {
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Request-Id", HeaderValue::from_static("req-42"));
+        headers.insert("Accept", HeaderValue::from_static("application/json"));
+
+        let redacted = redact_headers(&headers);
+
+        assert_eq!(redacted.len(), 2);
+        assert_eq!(
+            header_value("X-Request-Id", &redacted).as_deref(),
+            Some("req-42")
+        );
+        assert_eq!(
+            header_value("Accept", &redacted).as_deref(),
+            Some("application/json")
+        );
+    }
 }


### PR DESCRIPTION
## Bug

`log_middleware` in `api/src/middleware.rs` debug-printed the full request/response `Parts` (including **all headers**, e.g. `Authorization`) and the raw request/response bodies to CloudWatch at `INFO` level on every request:

```rust
info!("Received request: {:?} {:?}", parts, body);
...
info!("Response: {:?} {:?}", parts, body);
```

This leaked:
- Discord OAuth access tokens and the internal bot token (via `Authorization`)
- OIDC tokens and email addresses carried in request/response bodies (e.g. `POST /users/{id}/links`)

to anyone with CloudWatch log read access, and buffered every body into memory unnecessarily on every call.

## Fix

- `log_middleware` no longer buffers or logs request/response bodies at all.
- Headers are still logged (useful for debugging method/URI/status/routing issues), but sensitive headers (`Authorization`, `Cookie`, `Set-Cookie`) are redacted to a fixed placeholder via a new `redact_headers` helper before being passed to `info!`.

## Tests

Added `#[cfg(test)] mod tests` in `api/src/middleware.rs` with 4 regression tests for `redact_headers`:
- `redact_headers_hides_authorization_value` — asserts the raw `Authorization` token never appears in the rendered output and is replaced with a placeholder.
- `redact_headers_is_case_insensitive` — confirms lowercase `authorization` header is also redacted.
- `redact_headers_hides_cookies` — confirms `Cookie`/`Set-Cookie` values are redacted too.
- `redact_headers_preserves_non_sensitive_headers_and_count` — confirms non-sensitive headers (e.g. `Accept`, `X-Request-Id`) pass through unchanged.

Verified with:
```
cargo test -p api redact_headers   # 4 passed
cargo check -p api                 # clean, no warnings/errors
```

Closes #16

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZWfJfvGVV3o7JxzUHGBMG)_