### PR TITLE
fix(api): get_current_user_guild can return the wrong guild and panics

### DIFF
--- a/api/src/discord.rs
+++ b/api/src/discord.rs
@@ -78,6 +78,26 @@ pub async fn get_current_user_guilds(client: &Client) -> Result<Vec<CurrentUserG
         .map_err(ise)
 }
 
+/// Selects the guild matching `guild_id` out of a batch of the current
+/// user's guilds returned by Discord.
+///
+/// Discord's `after`/`limit` pagination on `Get Current User Guilds` only
+/// narrows the search space to "the next guild after this ID" — it does not
+/// guarantee that guild is actually the one requested (the user may not be a
+/// member of `guild_id` at all, in which case Discord returns whichever
+/// guild the client *is* in with the next-highest snowflake). Callers must
+/// therefore verify the ID before trusting any fields (owner/permissions)
+/// on the returned guild, otherwise an authorization check can silently
+/// evaluate a different guild than the one requested.
+///
+/// Returns `None` — never panics — if none of the supplied guilds match.
+fn select_current_user_guild(
+    guilds: Vec<CurrentUserGuild>,
+    guild_id: Id<GuildMarker>,
+) -> Option<CurrentUserGuild> {
+    guilds.into_iter().find(|g| g.id == guild_id)
+}
+
 #[cached(
     time = 180,
     key = "String",
@@ -86,8 +106,8 @@ pub async fn get_current_user_guilds(client: &Client) -> Result<Vec<CurrentUserG
 pub async fn get_current_user_guild(
     guild_id: Id<GuildMarker>,
     client: &Client,
-) -> Result<CurrentUserGuild, StatusCode> {
-    Ok(retry_on_rl(|| async {
+) -> Result<Option<CurrentUserGuild>, StatusCode> {
+    let guilds = retry_on_rl(|| async {
         client
             .current_user_guilds()
             .after(Id::new(guild_id.get() - 1))
@@ -98,9 +118,74 @@ pub async fn get_current_user_guild(
     .map_err(as_http_err)?
     .models()
     .await
-    .map_err(ise)?
-    .pop()
-    .unwrap())
+    .map_err(ise)?;
+
+    Ok(select_current_user_guild(guilds, guild_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use twilight_model::guild::Permissions;
+
+    fn guild(id: u64, owner: bool) -> CurrentUserGuild {
+        CurrentUserGuild {
+            id: Id::new(id),
+            name: format!("guild-{id}"),
+            icon: None,
+            owner,
+            permissions: if owner {
+                Permissions::ADMINISTRATOR
+            } else {
+                Permissions::empty()
+            },
+            features: vec![],
+        }
+    }
+
+    #[test]
+    fn returns_the_matching_guild_when_user_has_multiple_guilds() {
+        let guilds = vec![guild(100, false), guild(200, true), guild(300, false)];
+
+        let found = select_current_user_guild(guilds, Id::new(200));
+
+        assert_eq!(found.map(|g| g.id), Some(Id::new(200)));
+    }
+
+    #[test]
+    fn returns_none_instead_of_panicking_when_guild_not_found() {
+        let guilds = vec![guild(100, false), guild(300, false)];
+
+        // Regression: previously `.pop().unwrap()` on an unmatched batch
+        // would panic (HTTP 500) instead of yielding a clean "not a member"
+        // result.
+        let found = select_current_user_guild(guilds, Id::new(200));
+
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn returns_none_when_no_guilds_at_all() {
+        let found = select_current_user_guild(vec![], Id::new(200));
+
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn does_not_leak_data_from_a_different_guild() {
+        // Regression: `.after(guild_id - 1).limit(1)` can return the next
+        // guild by snowflake order when the user isn't a member of the
+        // requested guild. The selector must not treat that guild as a
+        // match, or an admin of guild `999` would be authorized for the
+        // unrelated, higher-privileged guild `1000`.
+        let other_guild = guild(1000, true);
+        let guilds = vec![other_guild.clone()];
+
+        let found = select_current_user_guild(guilds, Id::new(999));
+
+        assert!(found.is_none());
+        assert_ne!(found, Some(other_guild));
+    }
 }
 
 pub async fn add_guild_member_role(

--- a/api/src/guilds/utils.rs
+++ b/api/src/guilds/utils.rs
@@ -32,11 +32,12 @@ async fn is_client_admin_guild(
     guild_id: Id<GuildMarker>,
     client: &twilight_http::Client,
 ) -> Result<bool, StatusCode> {
-    let guild = get_current_user_guild(guild_id, client).await?;
-    if guild.owner || guild.permissions & Permissions::ADMINISTRATOR == Permissions::ADMINISTRATOR {
-        return Ok(true);
+    match get_current_user_guild(guild_id, client).await? {
+        Some(guild) => Ok(
+            guild.owner || guild.permissions & Permissions::ADMINISTRATOR == Permissions::ADMINISTRATOR,
+        ),
+        None => Ok(false),
     }
-    Ok(false)
 }
 
 pub async fn is_intersect_admin_guild(

--- a/api/src/meta/guilds.rs
+++ b/api/src/meta/guilds.rs
@@ -96,7 +96,9 @@ async fn get_meta_guilds_id(
         return Err(StatusCode::NOT_FOUND);
     }
 
-    let u_guild = get_current_user_guild(guild_id, &discord_user).await?;
+    let u_guild = get_current_user_guild(guild_id, &discord_user)
+        .await?
+        .ok_or(StatusCode::NOT_FOUND)?;
     let guild = get_guild(guild_id, &app_state.discord_bot).await?;
     let channels = get_guild_channels(guild_id, &app_state.discord_bot).await?;
 

--- a/api/src/users/link_guilds.rs
+++ b/api/src/users/link_guilds.rs
@@ -31,7 +31,7 @@ async fn put_link_guilds_id(
     Extension(discord_user): Extension<Arc<twilight_http::Client>>,
     State(app_state): State<AppState>,
 ) -> Result<Json<Value>, StatusCode> {
-    if current_user.id != user_id || !is_client_guild_member(guild_id, &discord_user).await {
+    if current_user.id != user_id || !is_client_guild_member(guild_id, &discord_user).await? {
         return Err(StatusCode::UNAUTHORIZED);
     }
 
@@ -97,7 +97,7 @@ async fn delete_link_guilds_id(
     Extension(discord_user): Extension<Arc<twilight_http::Client>>,
     State(app_state): State<AppState>,
 ) -> Result<StatusCode, StatusCode> {
-    if current_user.id != user_id || !is_client_guild_member(guild_id, &discord_user).await {
+    if current_user.id != user_id || !is_client_guild_member(guild_id, &discord_user).await? {
         return Err(StatusCode::UNAUTHORIZED);
     }
 
@@ -124,6 +124,9 @@ async fn delete_link_guilds_id(
     guild.save(&app_state.pg_pool).await;
     Ok(StatusCode::NO_CONTENT)
 }
-async fn is_client_guild_member(guild_id: Id<GuildMarker>, client: &twilight_http::Client) -> bool {
-    get_current_user_guild(guild_id, client).await.is_ok()
+async fn is_client_guild_member(
+    guild_id: Id<GuildMarker>,
+    client: &twilight_http::Client,
+) -> Result<bool, StatusCode> {
+    Ok(get_current_user_guild(guild_id, client).await?.is_some())
 }


### PR DESCRIPTION
## Security bug

`get_current_user_guild` in `api/src/discord.rs` fetched the caller's guild with:

```rust
client.current_user_guilds().after(Id::new(guild_id.get() - 1)).limit(1).await
```
```rust
.pop().unwrap()
```

This has two defects, both security-relevant since this function backs authorization checks:

1. **Wrong guild returned.** `.after(guild_id - 1).limit(1)` returns the client's first guild with an ID greater than `guild_id - 1`, which is only the requested guild if the client is actually a member of it. If not, the *next* guild by snowflake order is returned instead, and callers evaluate owner/permission bits of a *different* guild. `is_client_guild_member` (in `api/src/users/link_guilds.rs`) only checked `.is_ok()`, so a user in any guild with a higher snowflake ID than the target passed the membership check for `PUT /users/{id}/link_guilds/{guild_id}` on a guild they never joined.
2. **Panic.** If no guild follows, `.pop()` returned `None` and `.unwrap()` panicked, turning a "not found" case into an HTTP 500 / crashed Lambda invocation instead of a clean auth failure.

## Fix

- `get_current_user_guild` now returns `Result<Option<CurrentUserGuild>, StatusCode>`. It still uses the same Discord pagination call (since `guild_id` is always the smallest possible match after `guild_id - 1` when present), but now extracts the match via a pure, unit-testable helper `select_current_user_guild` that does `.find(|g| g.id == guild_id)` instead of blindly trusting `.pop()`. "Not a member" is now representable data (`None`), never a panic or the wrong guild.
- Updated all call sites to handle the `Option`:
  - `api/src/guilds/utils.rs` (`is_client_admin_guild` → used by `is_intersect_admin_guild` → `GET /guilds/{id}`, `GET /meta/guilds/{id}`): `None` → not admin.
  - `api/src/users/link_guilds.rs` (`is_client_guild_member`): now returns `Result<bool, StatusCode>` and propagates Discord API errors instead of collapsing them (and everything else) to `false`, as flagged in the issue.
  - `api/src/meta/guilds.rs` (`get_meta_guilds_id`): now returns `404 NOT_FOUND` instead of the old implicit panic path.

## Tests

Added regression unit tests for `select_current_user_guild` in `api/src/discord.rs` covering:
- the correct guild is picked out of a batch containing multiple guild entries,
- `None` (never a panic) is returned when the user has no entry matching the requested `guild_id`,
- an empty guild list also yields `None`,
- no other guild's data leaks through when the only guild returned is *not* the one requested (the core wrong-guild leak scenario from the report).

## Verification

- `cargo check -p api` — clean.
- `cargo test -p api discord::tests::` — all new regression tests pass (ran in a separate foreground invocation after clearing a stale target-dir lock from a prior contended run).

Closes #15


---
_Generated by [Claude Code](https://claude.ai/code/session_01EZWfJfvGVV3o7JxzUHGBMG)_