### PR TITLE
Fix mobile UI responsiveness across dashboard, home, and verify pages

### DIFF
--- a/ui/src/components/ConfirmModal.test.js
+++ b/ui/src/components/ConfirmModal.test.js
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import ConfirmModal from "./ConfirmModal.vue";
+
+// ConfirmModal used a fixed `w-96` (384px) modal box, wider than common
+// phone viewports (320-375px), clipping the confirm/cancel buttons on
+// mobile. It needs to shrink on narrow screens (w-11/12) while capping out
+// at the original size on larger ones.
+
+describe("ConfirmModal mobile responsiveness", () => {
+  let modalTarget;
+
+  beforeEach(() => {
+    modalTarget = document.createElement("div");
+    modalTarget.id = "modal";
+    document.body.appendChild(modalTarget);
+  });
+
+  afterEach(() => {
+    modalTarget.remove();
+  });
+
+  it("sizes the modal box to shrink on narrow viewports", () => {
+    const wrapper = mount(ConfirmModal, {
+      props: {
+        title: "Delete?",
+        confirmClass: "btn-error",
+        confirmText: "confirm",
+        activeEvent: { target: { id: "1" } },
+      },
+      attachTo: document.body,
+    });
+
+    const modalBox = document.querySelector(".modal-box");
+    expect(modalBox).not.toBeNull();
+    expect(modalBox.classList.contains("w-11/12")).toBe(true);
+
+    wrapper.unmount();
+  });
+});

--- a/ui/src/components/ConfirmModal.vue
+++ b/ui/src/components/ConfirmModal.vue
@@ -24,7 +24,7 @@ watchEffect(() => {
 <template>
   <Teleport to="#modal">
     <div class="modal" :class="storedActiveEvent ? 'modal-open' : ''" >
-      <div class="modal-box w-96 bg-base-300 flex flex-col" ref="modalBox">
+      <div class="modal-box w-11/12 max-w-96 bg-base-300 flex flex-col" ref="modalBox">
         <div class="flex flex-row justify-between">
           <h3 class="text-lg font-bold mb-5">{{ title }}</h3>
         </div>

--- a/ui/src/components/auth/DiscordAuthButton.test.js
+++ b/ui/src/components/auth/DiscordAuthButton.test.js
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import DiscordAuthButton from "./DiscordAuthButton.vue";
+import { User } from "../../stores/user.js";
+import { OauthToken } from "../../helpers/auth.js";
+import { UserMeta } from "../../stores/meta.js";
+
+// The logged-in account modal used a fixed `w-96` (384px) box, wider than
+// common phone viewports (320-375px), clipping the username/logout button
+// on mobile. It needs to shrink on narrow screens (w-11/12) while capping
+// out at the original size on larger ones.
+
+function loggedInUser() {
+  const token = new OauthToken();
+  token.accessToken = "token-a";
+  return new User("user-1", [], [], token);
+}
+
+describe("DiscordAuthButton mobile responsiveness", () => {
+  let modalTarget;
+
+  beforeEach(() => {
+    modalTarget = document.createElement("div");
+    modalTarget.id = "modal";
+    document.body.appendChild(modalTarget);
+  });
+
+  afterEach(() => {
+    modalTarget.remove();
+  });
+
+  it("sizes the account modal to shrink on narrow viewports", async () => {
+    const wrapper = mount(DiscordAuthButton, {
+      props: {
+        user: loggedInUser(),
+        userMeta: new UserMeta("user-1", "Test User", null),
+      },
+      attachTo: document.body,
+    });
+
+    await wrapper.find("button.btn").trigger("click");
+    await wrapper.vm.$nextTick();
+
+    const modalBox = document.querySelector(".modal-box");
+    expect(modalBox).not.toBeNull();
+    expect(modalBox.classList.contains("w-11/12")).toBe(true);
+
+    wrapper.unmount();
+  });
+});

--- a/ui/src/components/auth/DiscordAuthButton.vue
+++ b/ui/src/components/auth/DiscordAuthButton.vue
@@ -64,7 +64,7 @@ function logout() {
 
   <Teleport to="#modal">
     <div class="modal" :class="modalActiveRef ? 'modal-open' : ''" v-if="isUserLoggedIn(props.user)" >
-      <div class="modal-box w-96 bg-base-300 flex flex-col" ref="modalBox">
+      <div class="modal-box w-11/12 max-w-96 bg-base-300 flex flex-col" ref="modalBox">
         <div class="flex flex-row justify-between">
           <h3 class="text-lg font-bold">Logged in as {{ props.userMeta ? props.userMeta.globalName : '' }}</h3>
 

--- a/ui/src/components/dashboard/AnnounceComponent.test.js
+++ b/ui/src/components/dashboard/AnnounceComponent.test.js
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import rawSource from "./AnnounceComponent.vue?raw";
+import { parseComponentTemplate } from "../../testUtils/templateDom.js";
+
+// The announcements table (Title/Members/Sent/actions columns) is wider
+// than common phone viewports. It's currently hidden behind a hardcoded
+// `skeleton` flag ("Coming Soon"), but the markup must already be wrapped
+// for horizontal scrolling on mobile so the page never has to scroll
+// sideways once the feature ships.
+
+describe("AnnounceComponent mobile responsiveness", () => {
+  it("wraps the announcements table in a horizontally scrollable container", () => {
+    const dom = parseComponentTemplate(rawSource);
+    const table = dom.querySelector("table.table");
+    expect(table).not.toBeNull();
+    expect(table.closest(".overflow-x-auto")).not.toBeNull();
+  });
+});

--- a/ui/src/components/dashboard/AnnounceComponent.vue
+++ b/ui/src/components/dashboard/AnnounceComponent.vue
@@ -13,7 +13,8 @@ let skeleton = true
         <button class="btn btn-primary btn-sm justify-end" v-if="!skeleton">Create</button>
       </div>
       <div class="divider my-0"></div>
-      <table class="table" v-if="!skeleton">
+      <div class="overflow-x-auto" v-if="!skeleton">
+      <table class="table">
         <thead>
         <tr>
           <th>Title</th>
@@ -67,6 +68,7 @@ let skeleton = true
         </tr>
         </tbody>
       </table>
+      </div>
       <div class="skeleton h-48 text-center font-bold p-20" v-if="skeleton"> Coming Soon </div>
     </div>
   </div>

--- a/ui/src/components/dashboard/StreamAlertComponent.test.js
+++ b/ui/src/components/dashboard/StreamAlertComponent.test.js
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import rawSource from "./StreamAlertComponent.vue?raw";
+import { parseComponentTemplate } from "../../testUtils/templateDom.js";
+
+// Same mobile-scrolling issue as AnnounceComponent: the stream alerts table
+// (Channel/Type/Name/Last Live/actions columns) needs a horizontally
+// scrollable wrapper so it doesn't force the whole page to scroll sideways
+// on narrow viewports.
+
+describe("StreamAlertComponent mobile responsiveness", () => {
+  it("wraps the stream alerts table in a horizontally scrollable container", () => {
+    const dom = parseComponentTemplate(rawSource);
+    const table = dom.querySelector("table.table");
+    expect(table).not.toBeNull();
+    expect(table.closest(".overflow-x-auto")).not.toBeNull();
+  });
+});

--- a/ui/src/components/dashboard/StreamAlertComponent.vue
+++ b/ui/src/components/dashboard/StreamAlertComponent.vue
@@ -13,7 +13,8 @@ let skeleton = true
         <button class="btn btn-primary btn-sm justify-end" v-if="!skeleton">Add</button>
       </div>
       <div class="divider my-0"></div>
-      <table class="table" v-if="!skeleton">
+      <div class="overflow-x-auto" v-if="!skeleton">
+      <table class="table">
         <thead>
         <tr>
           <th>Channel</th>
@@ -76,6 +77,7 @@ let skeleton = true
         </tr>
         </tbody>
       </table>
+      </div>
       <div class="skeleton h-48 text-center font-bold p-20" v-if="skeleton"> Coming Soon </div>
     </div>
   </div>

--- a/ui/src/components/dashboard/SystemComponent.test.js
+++ b/ui/src/components/dashboard/SystemComponent.test.js
@@ -1,0 +1,38 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import SystemComponent from "./SystemComponent.vue";
+
+// The extension-info modal used a fixed `w-96` (384px) box. That's wider
+// than common phone viewports (320-375px), so the modal content gets
+// clipped/overflows on mobile. It needs to shrink on narrow screens
+// (w-11/12) while still capping out at the original size on larger ones.
+
+describe("SystemComponent mobile responsiveness", () => {
+  let modalTarget;
+
+  beforeEach(() => {
+    modalTarget = document.createElement("div");
+    modalTarget.id = "modal";
+    document.body.appendChild(modalTarget);
+  });
+
+  afterEach(() => {
+    modalTarget.remove();
+  });
+
+  it("sizes the extension info modal to shrink on narrow viewports", async () => {
+    const wrapper = mount(SystemComponent, {
+      global: { stubs: { fa: true } },
+      attachTo: document.body,
+    });
+
+    await wrapper.find("button.btn-sm").trigger("click");
+    await wrapper.vm.$nextTick();
+
+    const modalBox = document.querySelector(".modal-box");
+    expect(modalBox).not.toBeNull();
+    expect(modalBox.classList.contains("w-11/12")).toBe(true);
+
+    wrapper.unmount();
+  });
+});

--- a/ui/src/components/dashboard/SystemComponent.vue
+++ b/ui/src/components/dashboard/SystemComponent.vue
@@ -54,7 +54,7 @@ let extensions = new Map([
 
   <Teleport to="#modal">
     <div class="modal" :class="selected ? 'modal-open' : ''" v-if='selected' >
-      <div class="modal-box w-96 bg-base-300 flex flex-col" ref="modalBox">
+      <div class="modal-box w-11/12 max-w-96 bg-base-300 flex flex-col" ref="modalBox">
         <div class="card-body">
           <div class="card-title">
             {{selected}}

--- a/ui/src/components/dashboard/VerifyComponent.test.js
+++ b/ui/src/components/dashboard/VerifyComponent.test.js
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import VerifyComponent from "./VerifyComponent.vue";
+import { Guild, Vote, Verify } from "../../stores/guild.js";
+import { GuildMeta } from "../../stores/meta.js";
+
+// The verified-roles table (Role/Type/Pattern/Members/actions columns) is
+// wider than common phone viewports and needs a horizontally scrollable
+// wrapper so it doesn't force the whole page to scroll sideways on mobile.
+
+describe("VerifyComponent mobile responsiveness", () => {
+  let modalTarget;
+
+  beforeEach(() => {
+    modalTarget = document.createElement("div");
+    modalTarget.id = "modal";
+    document.body.appendChild(modalTarget);
+  });
+
+  afterEach(() => {
+    modalTarget.remove();
+  });
+
+  it("wraps the verified roles table in a horizontally scrollable container", () => {
+    const wrapper = mount(VerifyComponent, {
+      props: {
+        guild: new Guild("guild-1", new Verify([], new Map()), new Vote([])),
+        guildMeta: new GuildMeta("guild-1", "Test Guild", null, true, [], []),
+      },
+      global: {
+        stubs: { fa: true, RoleSelect: true, RoleTag: true },
+      },
+      attachTo: document.body,
+    });
+
+    const table = wrapper.find("table.table");
+    expect(table.exists()).toBe(true);
+    expect(table.element.closest(".overflow-x-auto")).not.toBeNull();
+
+    wrapper.unmount();
+  });
+});

--- a/ui/src/components/dashboard/VerifyComponent.vue
+++ b/ui/src/components/dashboard/VerifyComponent.vue
@@ -94,6 +94,7 @@ function validAdd() {
         <button class="btn btn-primary btn-sm justify-end" @click="modalActiveRef = true">Add</button>
       </div>
       <div class="divider my-0"></div>
+      <div class="overflow-x-auto">
       <table class="table">
         <thead>
         <tr>
@@ -133,11 +134,12 @@ function validAdd() {
         </tr>
         </tbody>
       </table>
+      </div>
     </div>
 
   <Teleport to="#modal">
     <div class="modal" :class="modalActiveRef ? 'modal-open' : ''" v-if="userRef">
-      <div class="modal-box w-96 bg-base-300 flex flex-col" ref="modalBox">
+      <div class="modal-box w-11/12 max-w-96 bg-base-300 flex flex-col" ref="modalBox">
         <div class="flex flex-row justify-between">
           <h3 class="text-lg font-bold">Add Verified Role</h3>
         </div>

--- a/ui/src/components/dashboard/VoteComponent.responsive.test.js
+++ b/ui/src/components/dashboard/VoteComponent.responsive.test.js
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import VoteComponent from "./VoteComponent.vue";
+import { User } from "../../stores/user.js";
+import { Guild, Vote, Verify } from "../../stores/guild.js";
+import { GuildMeta } from "../../stores/meta.js";
+
+// Mobile responsiveness regression tests.
+//
+// On narrow viewports the votes table (5 columns: Title, Description, State,
+// Voters, actions) is wider than the screen. Without a horizontally
+// scrollable wrapper, the table forces the whole page to scroll sideways
+// instead of just the table. Similarly the create/results modals used a
+// fixed `w-96` (384px) box which is wider than common phone viewports
+// (320-375px), clipping the modal content.
+
+function makeProps() {
+  return {
+    user: new User("user-1", [], [], null),
+    guild: new Guild("guild-1", new Verify([], new Map()), new Vote([])),
+    guildMeta: new GuildMeta("guild-1", "Test Guild", null, true, [], []),
+  };
+}
+
+function mountComponent() {
+  return mount(VoteComponent, {
+    props: makeProps(),
+    global: {
+      stubs: {
+        fa: true,
+        ChannelSelect: true,
+        RoleSelect: true,
+      },
+    },
+    attachTo: document.body,
+  });
+}
+
+describe("VoteComponent mobile responsiveness", () => {
+  let modalTarget;
+
+  beforeEach(() => {
+    modalTarget = document.createElement("div");
+    modalTarget.id = "modal";
+    document.body.appendChild(modalTarget);
+  });
+
+  afterEach(() => {
+    modalTarget.remove();
+  });
+
+  it("wraps the votes table in a horizontally scrollable container", () => {
+    const wrapper = mountComponent();
+    const table = wrapper.find("table.table");
+    expect(table.exists()).toBe(true);
+    expect(table.element.closest(".overflow-x-auto")).not.toBeNull();
+    wrapper.unmount();
+  });
+
+  it("sizes the create-vote modal to shrink on narrow viewports", async () => {
+    const wrapper = mountComponent();
+    await wrapper.find("button.btn-primary.btn-sm").trigger("click");
+    await wrapper.vm.$nextTick();
+
+    const modalBoxes = document.querySelectorAll(".modal-box");
+    expect(modalBoxes.length).toBeGreaterThan(0);
+    for (const box of modalBoxes) {
+      expect(box.classList.contains("w-11/12")).toBe(true);
+    }
+
+    wrapper.unmount();
+  });
+});

--- a/ui/src/components/dashboard/VoteComponent.vue
+++ b/ui/src/components/dashboard/VoteComponent.vue
@@ -129,6 +129,7 @@ function openResults(id) {
         <button class="btn btn-primary btn-sm justify-end" @click="modalActiveRef = 1">Create</button>
       </div>
       <div class="divider my-0"></div>
+      <div class="overflow-x-auto">
       <table class="table">
         <thead>
         <tr>
@@ -177,12 +178,13 @@ function openResults(id) {
         </tr>
         </tbody>
       </table>
+      </div>
     </div>
 
 
     <Teleport to="#modal">
       <div class="modal" :class="modalActiveRef === 1 ? 'modal-open' : ''">
-        <div class="modal-box w-96 bg-base-300 flex flex-col" ref="modalBox">
+        <div class="modal-box w-11/12 max-w-96 bg-base-300 flex flex-col" ref="modalBox">
           <div class="flex flex-row justify-between">
             <h3 class="text-lg font-bold">Create Vote</h3>
           </div>
@@ -240,7 +242,7 @@ function openResults(id) {
 
 
       <div class="modal" :class="modalActiveRef === 2 ? 'modal-open' : ''" v-if="selectedVote">
-        <div class="modal-box w-96 bg-base-300 flex flex-col" ref="modalBox">
+        <div class="modal-box w-11/12 max-w-96 bg-base-300 flex flex-col" ref="modalBox">
           <div class="flex flex-row justify-between">
             <h3 class="text-lg font-bold">Results</h3>
           </div>

--- a/ui/src/components/verify/LinkAccountButton.vue
+++ b/ui/src/components/verify/LinkAccountButton.vue
@@ -32,7 +32,7 @@ onClickOutside(modalBox, () => {
 
   <Teleport to="#modal">
     <div class="modal" :class="modalActiveRef ? 'modal-open' : ''" v-if="$props.user">
-      <div class="modal-box w-96 bg-base-300" ref="modalBox">
+      <div class="modal-box w-11/12 max-w-96 bg-base-300" ref="modalBox">
         <h3 class="text-lg font-bold">Link Account</h3>
         <div class="modal-action">
           <div class="flex flex-col h-auto w-full overflow-y-auto items-center">

--- a/ui/src/pages/HomeView.test.js
+++ b/ui/src/pages/HomeView.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import HomeView from "./HomeView.vue";
+
+// The landing page has several fixed-width (`w-96` = 384px) cards and a
+// non-wrapping partner-logo row. On phone viewports (320-375px) these force
+// the whole page to scroll horizontally instead of the cards shrinking to
+// fit, and the four partner logos get squeezed into one line instead of
+// wrapping.
+
+describe("HomeView mobile responsiveness", () => {
+  function mountView() {
+    return mount(HomeView, {
+      global: { stubs: { fa: true } },
+    });
+  }
+
+  it("shrinks the hero call-to-action card on narrow viewports", () => {
+    const wrapper = mountView();
+    const card = wrapper.find(".card.glass");
+    expect(card.exists()).toBe(true);
+    expect(card.classes()).toContain("w-11/12");
+  });
+
+  it("shrinks the feature cards on narrow viewports", () => {
+    const wrapper = mountView();
+    const cards = wrapper.findAll(".card.bg-base-100");
+    expect(cards.length).toBeGreaterThan(0);
+    for (const card of cards) {
+      expect(card.classes()).toContain("w-11/12");
+    }
+  });
+
+  it("allows the partner logos row to wrap on narrow viewports", () => {
+    const wrapper = mountView();
+    const partnerLinks = wrapper.findAll('a[href="https://www.thenuel.com"]');
+    expect(partnerLinks.length).toBe(1);
+    const row = partnerLinks[0].element.parentElement;
+    expect(row.classList.contains("flex-wrap")).toBe(true);
+  });
+});

--- a/ui/src/pages/HomeView.vue
+++ b/ui/src/pages/HomeView.vue
@@ -27,7 +27,7 @@ import MainWithFooter from "../components/MainWithFooter.vue";
 
           </div>
           <div class="flex flex-col">
-            <div class="card glass w-96 h-96 flex flex-col justify-self-center">
+            <div class="card glass w-11/12 max-w-96 h-96 flex flex-col justify-self-center">
               <div class="card-body flex flex-col justify-center h-max">
                 <h2 class="card-title justify-center">For Users</h2>
                 <div class="card-actions justify-center mx-5">
@@ -48,7 +48,7 @@ import MainWithFooter from "../components/MainWithFooter.vue";
       </div>
       <section class="flex flex-col justify-center items-center">
         <h1 class="title text-xl mt-10 font-bold prose-h1">Our Partners</h1>
-        <div class="flex flex-row justify-between">
+        <div class="flex flex-row flex-wrap justify-center">
           <a href="https://www.thenuel.com">
             <img class="max-h-28 max-w-52 m-5" src="../assets/NUEL-min.png"/>
           </a>
@@ -67,37 +67,37 @@ import MainWithFooter from "../components/MainWithFooter.vue";
       <section class="flex flex-col justify-center items-center bg-base-300 inset-shadow-2xs shadow-2xl">
         <h1 class="title text-xl mt-10 font-bold prose-h1">Features</h1>
         <div class="grid lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1">
-        <div class="card bg-base-100 w-96 m-10">
+        <div class="card bg-base-100 w-11/12 max-w-96 m-5 sm:m-10">
           <div class="card-body">
             <h2 class="card-title"><fa :icon="['fas', 'graduation-cap']" class="text-primary"/>By Students, For Students</h2>
             <p>We are a group of developers from universities around the UK, including The University of Southampton and Imperial College London, and we are keen to create a bot that will be key to growing societies to new limits!</p>
           </div>
         </div>
-        <div class="card bg-base-100 w-96 m-10">
+        <div class="card bg-base-100 w-11/12 max-w-96 m-5 sm:m-10">
           <div class="card-body">
             <h2 class="card-title"><fa :icon="['fas', 'unlock']" class="text-primary"/>Open Source</h2>
             <p>Our bot is completely open source to allow anyone to add additional functionality. We purposefully use an easy to learn programming language for our bot (Python) to allow all students to edit and understand our code.</p>
           </div>
         </div>
-        <div class="card bg-base-100 w-96 m-10">
+        <div class="card bg-base-100 w-11/12 max-w-96 m-5 sm:m-10">
           <div class="card-body">
             <h2 class="card-title"><fa :icon="['fas', 'gauge-high']" class="text-primary"/>Online Dashboard</h2>
             <p>To enable you to make changes to your bot's settings we are looking to create an online dashboard to allow admins to edit settings all from one webpage without needing to learn all the commands! Now Here!</p>
           </div>
         </div>
-        <div class="card bg-base-100 w-96 m-10">
+        <div class="card bg-base-100 w-11/12 max-w-96 m-5 sm:m-10">
           <div class="card-body">
             <h2 class="card-title"><fa :icon="['fas', 'flag']" class="text-primary"/>One Bot To Rule Them All</h2>
             <p>A lot of bots are really good at one thing and to enable a lot of functionality you will need 4, 5 or even more discord bots! To prevent you from having to know all the different bot prefixes and uses we want to make a modular bot with many 'Koala Extensions' that can be enabled and disabled at will to give you more or less functionality.</p>
           </div>
         </div>
-        <div class="card bg-base-100 w-96 m-10">
+        <div class="card bg-base-100 w-11/12 max-w-96 m-5 sm:m-10">
           <div class="card-body">
             <h2 class="card-title"><fa :icon="['fas', 'pen-to-square']" class="text-primary"/>Society Specific Functionality</h2>
             <p>We work with UK societies to find functionality key to them to enable their society to grow faster and easier. Koala extensions like 'Verify' allow students to verify their student email and gain a role automatically to view the rest of the server. We take feedback and suggestions to improve, alter and create our extensions to allow all societies to utilize Koala to its fullest!</p>
           </div>
         </div>
-        <div class="card bg-base-100 w-96 m-10">
+        <div class="card bg-base-100 w-11/12 max-w-96 m-5 sm:m-10">
           <div class="card-body">
             <h2 class="card-title"><fa :icon="['fas', 'comment']" class="text-primary"/>Feedback And Suggestions</h2>
             <p>We have a support discord where people can easily contact the developers to give suggestions or bugs reports with ease!</p>

--- a/ui/src/pages/verify/VerifyView.test.js
+++ b/ui/src/pages/verify/VerifyView.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import axios from "axios";
+import VerifyView from "./VerifyView.vue";
+import { User } from "../../stores/user.js";
+import { OauthToken } from "../../helpers/auth.js";
+
+// The hero image only had `lg:w-80 lg:h-full` (explicitly flagged
+// `<!-- fixme: responsive -->` in the source). Below the `lg` breakpoint it
+// has no width constraint at all, so it renders at its huge natural
+// intrinsic size and forces the whole page to scroll horizontally on phones
+// and tablets.
+
+vi.mock("axios");
+
+function loggedInUser() {
+  const token = new OauthToken();
+  token.accessToken = "token-a";
+  localStorage.setItem(
+    "user",
+    JSON.stringify({ userId: "user-1", links: [], linkGuilds: [], token }),
+  );
+  return new User("user-1", [], [], token);
+}
+
+describe("VerifyView mobile responsiveness", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    axios.get.mockImplementation((url) => {
+      if (url.includes("/users/")) {
+        return Promise.resolve({
+          data: { user_id: "user-1", links: [], link_guilds: [] },
+        });
+      }
+      return Promise.resolve({ data: [] });
+    });
+  });
+
+  it("constrains the hero image width below the lg breakpoint", () => {
+    loggedInUser();
+    const wrapper = mount(VerifyView, {
+      global: {
+        stubs: {
+          fa: true,
+          DiscordAuthButton: true,
+          LinkedAccountsTable: true,
+          LinkAccountButton: true,
+          LinkedGuildsSelect: true,
+        },
+      },
+    });
+
+    const img = wrapper.find("figure img");
+    expect(img.exists()).toBe(true);
+    expect(img.classes()).toContain("w-full");
+
+    wrapper.unmount();
+  });
+});

--- a/ui/src/pages/verify/VerifyView.vue
+++ b/ui/src/pages/verify/VerifyView.vue
@@ -32,9 +32,9 @@ onMounted(async () => {
     <div class="card lg:card-side w-auto bg-base-100 shadow-xl">
       <figure>
         <img
-            class="object-cover lg:w-80 lg:h-full"
+            class="object-cover w-full h-48 lg:w-80 lg:h-full"
             src="https://images.unsplash.com/photo-1519003300449-424ad0405076?q=80&w=2198&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
-            alt="Movie"/> <!-- fixme: responsive -->
+            alt="Movie"/>
       </figure>
       <div class="card-body flex flex-col justify-items-center">
         <h1 class="card-title text-xl font-bold self-center">KoalaBot Verify</h1>

--- a/ui/src/testUtils/templateDom.js
+++ b/ui/src/testUtils/templateDom.js
@@ -1,0 +1,15 @@
+// AnnounceComponent/StreamAlertComponent hide their table behind a hardcoded
+// `skeleton = true` plain (non-reactive) local variable, so there's no way
+// to toggle it into view through a normal @vue/test-utils mount. Parsing the
+// raw <template> block as HTML lets us assert on the *structure* Vue will
+// render (e.g. "is this <table> nested inside a div.overflow-x-auto") without
+// needing the component to actually be in that state at runtime.
+export function parseComponentTemplate(rawSource) {
+  const match = rawSource.match(/<template>([\s\S]*)<\/template>/);
+  if (!match) {
+    throw new Error("No <template> block found in component source");
+  }
+  const container = document.createElement("div");
+  container.innerHTML = match[1];
+  return container;
+}


### PR DESCRIPTION
Several components broke layout on narrow viewports:
- Vote/Verify/Announce/StreamAlert tables had no horizontal-scroll
  wrapper, forcing the whole page to scroll sideways instead of just
  the table.
- Modals used a fixed w-96 (384px) box, wider than common phone
  viewports (320-375px); switched to w-11/12 max-w-96 so they shrink
  on narrow screens.
- HomeView's hero and feature cards were fixed-width (w-96) and the
  partner logo row didn't wrap, both overflowing on mobile.
- VerifyView's hero image (marked "fixme: responsive") had no width
  constraint below the lg breakpoint.

Added regression tests (TDD: written failing first) covering each fix.