### PR TITLE
Fix dashboard header navbar overlap/wrapping on mobile

### DIFF
--- a/ui/src/pages/dashboard/DashBaseView.test.js
+++ b/ui/src/pages/dashboard/DashBaseView.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import rawSource from "./DashBaseView.vue?raw";
+import { parseComponentTemplate } from "../../testUtils/templateDom.js";
+
+// The dashboard header navbar breaks on phone viewports:
+// - The current-guild button had no width cap or truncation, so a normal
+//   length server name (e.g. "Koala Bots") wraps onto two lines using the
+//   oversized `card-title` font, roughly doubling the header's height.
+// - navbar-end had a flat `px-10` (80px) of horizontal padding, which eats
+//   a large chunk of a ~375-414px viewport and crowds everything else.
+// - The center logo used a fixed size that doesn't shrink to make room.
+//
+// DashBaseView has heavy onMounted data-loading side effects, so rather
+// than fully mounting it we parse its raw <template> to assert on the
+// structure Vue will render.
+
+describe("DashBaseView mobile responsiveness", () => {
+  it("truncates the current-guild name instead of letting it wrap", () => {
+    const dom = parseComponentTemplate(rawSource);
+    const nameLabel = Array.from(dom.querySelectorAll("*")).find(
+      (el) =>
+        el.children.length === 0 &&
+        el.textContent.includes("guildMetaMap.get(currentGuildId).name"),
+    );
+    expect(nameLabel).toBeTruthy();
+    expect(nameLabel.classList.contains("truncate")).toBe(true);
+
+    const guildButton = nameLabel.closest('[role="button"]');
+    expect(guildButton).toBeTruthy();
+    expect(guildButton.className).toMatch(/max-w-/);
+  });
+
+  it("shrinks the navbar-end padding on narrow viewports", () => {
+    const dom = parseComponentTemplate(rawSource);
+    const navbarEnd = dom.querySelector(".navbar-end");
+    expect(navbarEnd).toBeTruthy();
+    expect(navbarEnd.classList.contains("px-2")).toBe(true);
+    expect(navbarEnd.classList.contains("sm:px-10")).toBe(true);
+  });
+
+  it("shrinks the center logo on narrow viewports", () => {
+    const dom = parseComponentTemplate(rawSource);
+    // Vue SFC custom component tags (KoalaMonoIcon) are lower-cased by the
+    // HTML parser used here, so just grab the element inside navbar-center.
+    const logoEl = dom.querySelector(".navbar-center a > *");
+    expect(logoEl).toBeTruthy();
+    expect(logoEl.className).toMatch(/h-8/);
+    expect(logoEl.className).toMatch(/sm:h-10/);
+  });
+});

--- a/ui/src/pages/dashboard/DashBaseView.test.js
+++ b/ui/src/pages/dashboard/DashBaseView.test.js
@@ -8,7 +8,12 @@ import { parseComponentTemplate } from "../../testUtils/templateDom.js";
 //   oversized `card-title` font, roughly doubling the header's height.
 // - navbar-end had a flat `px-10` (80px) of horizontal padding, which eats
 //   a large chunk of a ~375-414px viewport and crowds everything else.
-// - The center logo used a fixed size that doesn't shrink to make room.
+// - The center logo doesn't reserve its own space in the navbar (DaisyUI's
+//   navbar-start/navbar-end both stretch to fill the remaining width), so
+//   on narrow screens it visually collides with the account button next to
+//   it. It's decorative only (the koala branding is already in the browser
+//   tab and the page footer), so it's hidden below the sm breakpoint rather
+//   than fought over.
 //
 // DashBaseView has heavy onMounted data-loading side effects, so rather
 // than fully mounting it we parse its raw <template> to assert on the
@@ -38,13 +43,11 @@ describe("DashBaseView mobile responsiveness", () => {
     expect(navbarEnd.classList.contains("sm:px-10")).toBe(true);
   });
 
-  it("shrinks the center logo on narrow viewports", () => {
+  it("hides the decorative center logo on narrow viewports so it can't collide with the account button", () => {
     const dom = parseComponentTemplate(rawSource);
-    // Vue SFC custom component tags (KoalaMonoIcon) are lower-cased by the
-    // HTML parser used here, so just grab the element inside navbar-center.
-    const logoEl = dom.querySelector(".navbar-center a > *");
-    expect(logoEl).toBeTruthy();
-    expect(logoEl.className).toMatch(/h-8/);
-    expect(logoEl.className).toMatch(/sm:h-10/);
+    const navbarCenter = dom.querySelector(".navbar-center");
+    expect(navbarCenter).toBeTruthy();
+    expect(navbarCenter.classList.contains("hidden")).toBe(true);
+    expect(navbarCenter.classList.contains("sm:flex")).toBe(true);
   });
 });

--- a/ui/src/pages/dashboard/DashBaseView.vue
+++ b/ui/src/pages/dashboard/DashBaseView.vue
@@ -156,9 +156,9 @@ async function sync_guilds_kb() {
             </ul>
           </div>
         </div>
-        <div class="navbar-center shrink-0">
+        <div class="navbar-center hidden sm:flex">
           <a href="/">
-            <KoalaMonoIcon class="h-8 w-8 sm:h-10 sm:w-10 fill-base-content"/>
+            <KoalaMonoIcon class="h-10 w-10 fill-base-content"/>
           </a>
         </div>
         <div class="navbar-end px-2 sm:px-10">

--- a/ui/src/pages/dashboard/DashBaseView.vue
+++ b/ui/src/pages/dashboard/DashBaseView.vue
@@ -124,18 +124,18 @@ async function sync_guilds_kb() {
   <div class="flex flex-col h-full">
     <header class="w-full">
       <div class="navbar shadow m-5 w-auto bg-base-200">
-        <div class="navbar-start">
-          <div class="dropdown">
+        <div class="navbar-start min-w-0">
+          <div class="dropdown min-w-0">
             <div tabindex="0" role="button" class="btn btn-sm btn-primary" v-if="!currentGuildId">
               Select Server
             </div>
-            <div tabindex="0" role="button" class="card-title btn btn-sm btn-ghost" v-if="currentGuildId">
-              <div class="avatar">
+            <div tabindex="0" role="button" class="btn btn-sm btn-ghost max-w-40 sm:max-w-60" v-if="currentGuildId">
+              <div class="avatar shrink-0">
                 <div class="w-6 rounded-xl">
                   <img :src="`https://cdn.discordapp.com/icons/${currentGuildId}/${guildMetaMap.get(currentGuildId).icon}.webp`" v-if="guildMetaMap.get(currentGuildId) && guildMetaMap.get(currentGuildId).icon"/>
                 </div>
               </div>
-              {{ guildMetaMap.get(currentGuildId).name }}
+              <span class="truncate font-semibold">{{ guildMetaMap.get(currentGuildId).name }}</span>
             </div>
             <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-1 p-2 shadow-sm">
               <li v-if="!guildsLoaded">
@@ -146,7 +146,7 @@ async function sync_guilds_kb() {
               <li v-for="[gid, guild] in guildMetaMap">
                 <a :class="(gid === currentGuildId && 'menu-active')" @click="setCurrentGuild(guild.id)">
                 <div class="w-6 rounded-xl"><img :src="`https://cdn.discordapp.com/icons/${guild.id}/${guild.icon}.webp`" v-if="guild.icon"/>
-                </div> {{ guild.name }}</a>
+                </div> <span class="truncate">{{ guild.name }}</span></a>
               </li>
               <li class="bg-primary text-primary-content">
                 <a class="justify-between" :href="INVITE_URL">
@@ -156,12 +156,12 @@ async function sync_guilds_kb() {
             </ul>
           </div>
         </div>
-        <div class="navbar-center">
+        <div class="navbar-center shrink-0">
           <a href="/">
-            <KoalaMonoIcon class="h-10 w-10 fill-base-content"/>
+            <KoalaMonoIcon class="h-8 w-8 sm:h-10 sm:w-10 fill-base-content"/>
           </a>
         </div>
-        <div class="navbar-end px-10">
+        <div class="navbar-end px-2 sm:px-10">
           <DiscordAuthButton long-text="false" class="" :user="user" :user-meta="userMeta" @logout="reload"></DiscordAuthButton>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- The dashboard header's current-guild button had no width cap or truncation and used the oversized `card-title` font, so a normal server name (e.g. "Koala Bots") wrapped onto two lines and roughly doubled the header's height on phone viewports.
- `navbar-end` had a flat `px-10` (80px) of horizontal padding, eating a large chunk of a ~375-414px viewport and crowding the rest of the header.
- Fixing that padding revealed a second issue when rendered live: the center koala logo doesn't reserve its own space in the navbar (DaisyUI's `navbar-start`/`navbar-end` both stretch to fill the remaining width around it), so it visually collided with the account button. Since the branding is already duplicated in the browser tab and page footer, it's hidden below the `sm` breakpoint instead of fought over.

## Test plan
- [x] Added `DashBaseView.test.js` (TDD: written failing first) asserting the guild name truncates with a capped width, `navbar-end` padding is responsive, and the logo is hidden below `sm`
- [x] `npx vitest run` — 25/25 tests pass
- [x] `npm run build` succeeds
- [x] Manually rendered the dashboard in a browser at phone (390px) and tablet (800px) widths to confirm no wrapping/overlap and that the logo reappears correctly on wider screens


---
_Generated by [Claude Code](https://claude.ai/code/session_01HeonMsnJ5Sx77kpeMmn1Co)_