### PR TITLE
fix: split audit dedupe migration for Aurora DSQL constraint support

### DIFF
--- a/api/migrations/20260702120000_audit_sqs_dedupe_key.up.sql
+++ b/api/migrations/20260702120000_audit_sqs_dedupe_key.up.sql
@@ -1,2 +1,2 @@
 -- no-transaction
-ALTER TABLE audit ADD COLUMN sqs_message_id VARCHAR UNIQUE;
+ALTER TABLE audit ADD COLUMN sqs_message_id VARCHAR;

--- a/api/migrations/20260702120001_audit_sqs_dedupe_key_unique_index.down.sql
+++ b/api/migrations/20260702120001_audit_sqs_dedupe_key_unique_index.down.sql
@@ -1,0 +1,2 @@
+-- no-transaction
+DROP INDEX audit_sqs_message_id_key;

--- a/api/migrations/20260702120001_audit_sqs_dedupe_key_unique_index.up.sql
+++ b/api/migrations/20260702120001_audit_sqs_dedupe_key_unique_index.up.sql
@@ -1,0 +1,2 @@
+-- no-transaction
+CREATE UNIQUE INDEX audit_sqs_message_id_key ON audit (sqs_message_id);

--- a/api/migrations/20260702120001_audit_sqs_dedupe_key_unique_index.up.sql
+++ b/api/migrations/20260702120001_audit_sqs_dedupe_key_unique_index.up.sql
@@ -1,2 +1,2 @@
 -- no-transaction
-CREATE UNIQUE INDEX audit_sqs_message_id_key ON audit (sqs_message_id);
+CREATE UNIQUE INDEX ASYNC audit_sqs_message_id_key ON audit (sqs_message_id);


### PR DESCRIPTION
Aurora DSQL rejects ALTER TABLE ADD COLUMN with an inline UNIQUE
constraint and requires each DDL statement to commit in its own
transaction. Add the column plain, then create the unique index in a
separate migration file so sqlx-cli issues them as distinct
statements. ON CONFLICT (sqs_message_id) still works against the
unique index.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the database schema for audit records to allow more flexible handling of message identifiers.
  * Added rollback support for the new schema change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->